### PR TITLE
8299478: [Lilliput/JDK17] Fix Windows build

### DIFF
--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -126,7 +126,7 @@ GrowableArray<Klass*>* ArrayKlass::compute_secondary_supers(int num_extra_slots,
 
 objArrayOop ArrayKlass::allocate_arrayArray(int n, int length, TRAPS) {
   check_array_allocation_length(length, arrayOopDesc::max_array_length(T_ARRAY), CHECK_NULL);
-  int size = objArrayOopDesc::object_size(length);
+  size_t size = objArrayOopDesc::object_size(length);
   Klass* k = array_klass(n+dimension(), CHECK_NULL);
   ArrayKlass* ak = ArrayKlass::cast(k);
   objArrayOop o = (objArrayOop)Universe::heap()->array_allocate(ak, size, length,

--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -126,7 +126,7 @@ GrowableArray<Klass*>* ArrayKlass::compute_secondary_supers(int num_extra_slots,
 
 objArrayOop ArrayKlass::allocate_arrayArray(int n, int length, TRAPS) {
   check_array_allocation_length(length, arrayOopDesc::max_array_length(T_ARRAY), CHECK_NULL);
-  size_t size = objArrayOopDesc::object_size(length);
+  int size = objArrayOopDesc::object_size(length);
   Klass* k = array_klass(n+dimension(), CHECK_NULL);
   ArrayKlass* ak = ArrayKlass::cast(k);
   objArrayOop o = (objArrayOop)Universe::heap()->array_allocate(ak, size, length,

--- a/src/hotspot/share/oops/objArrayOop.hpp
+++ b/src/hotspot/share/oops/objArrayOop.hpp
@@ -69,15 +69,15 @@ private:
   oop atomic_compare_exchange_oop(int index, oop exchange_value, oop compare_value);
 
   // Sizing
-  size_t object_size()           { return object_size(length()); }
+  int object_size()           { return object_size(length()); }
 
-  static size_t object_size(int length) {
+  static int object_size(int length) {
     // This returns the object size in HeapWords.
     size_t asz = array_size_in_bytes(length);
     size_t size_words = align_up(base_offset_in_bytes() + asz, HeapWordSize) / HeapWordSize;
     size_t osz = align_object_size(size_words);
     assert(osz < max_jint, "no overflow");
-    return osz;
+    return static_cast<int>(osz);
   }
 
   Klass* element_klass();

--- a/src/hotspot/share/oops/objArrayOop.hpp
+++ b/src/hotspot/share/oops/objArrayOop.hpp
@@ -69,9 +69,9 @@ private:
   oop atomic_compare_exchange_oop(int index, oop exchange_value, oop compare_value);
 
   // Sizing
-  int object_size()           { return object_size(length()); }
+  size_t object_size()           { return object_size(length()); }
 
-  static int object_size(int length) {
+  static size_t object_size(int length) {
     // This returns the object size in HeapWords.
     size_t asz = array_size_in_bytes(length);
     size_t size_words = align_up(base_offset_in_bytes() + asz, HeapWordSize) / HeapWordSize;

--- a/src/hotspot/share/oops/objArrayOop.hpp
+++ b/src/hotspot/share/oops/objArrayOop.hpp
@@ -77,7 +77,7 @@ private:
     size_t size_words = align_up(base_offset_in_bytes() + asz, HeapWordSize) / HeapWordSize;
     size_t osz = align_object_size(size_words);
     assert(osz < max_jint, "no overflow");
-    return static_cast<int>(osz);
+    return checked_cast<int>(osz);
   }
 
   Klass* element_klass();

--- a/src/hotspot/share/oops/typeArrayOop.hpp
+++ b/src/hotspot/share/oops/typeArrayOop.hpp
@@ -131,7 +131,7 @@ private:
   }
 
  public:
-  inline size_t object_size(const TypeArrayKlass* tk) const;
+  inline int object_size(const TypeArrayKlass* tk) const;
 };
 
 #endif // SHARE_OOPS_TYPEARRAYOOP_HPP

--- a/src/hotspot/share/oops/typeArrayOop.inline.hpp
+++ b/src/hotspot/share/oops/typeArrayOop.inline.hpp
@@ -31,7 +31,7 @@
 #include "oops/oop.inline.hpp"
 #include "oops/arrayOop.hpp"
 
-size_t typeArrayOopDesc::object_size(const TypeArrayKlass* tk) const {
+int typeArrayOopDesc::object_size(const TypeArrayKlass* tk) const {
   return object_size(tk->layout_helper(), length());
 }
 

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -93,7 +93,7 @@
 #include "runtime/monitorDeflationThread.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/nonJavaThread.hpp"
-#include "runtime/objectMonitor.hpp"
+#include "runtime/objectMonitor.inline.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/osThread.hpp"
 #include "runtime/prefetch.inline.hpp"


### PR DESCRIPTION
These changes should fix the Windows (and MacOS) build of Lilliput/JDK17. I'm going blindly, here, only guided by GHA.

Ok?

Thanks,
Roman

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299478](https://bugs.openjdk.org/browse/JDK-8299478): [Lilliput/JDK17] Fix Windows build


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u pull/1/head:pull/1` \
`$ git checkout pull/1`

Update a local copy of the PR: \
`$ git checkout pull/1` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u pull/1/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1`

View PR using the GUI difftool: \
`$ git pr show -t 1`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/1.diff">https://git.openjdk.org/lilliput-jdk17u/pull/1.diff</a>

</details>
