### PR TITLE
8300566: [Lilliput/JDK17] Properly set ZF on anon-check path

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3964,7 +3964,11 @@ encode %{
     if (UseFastLocking) {
       // If the owner is anonymous, we need to fix it -- in the slow-path.
       __ ldr(disp_hdr, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
-      __ tbnz(disp_hdr, (unsigned char)(intptr_t) ANONYMOUS_OWNER, cont);
+      // We cannot use tbnz here: tbnz would leave the condition flags untouched,
+      // but we want to carry-over the NE condition to the exit at the cont label,
+      // in order to take the slow-path.
+      __ tst(disp_hdr, (uint64_t)(intptr_t) ANONYMOUS_OWNER);
+      __ br(Assembler::NE, cont);
     }
 
     __ ldr(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));


### PR DESCRIPTION
In AArch64's fast_unlock(), we need to check if the monitor owner is ANONYMOUS (only with Lilliput/fast-locking), and if so, call the runtime to fix this before exiting the monitor. I tried to be smart and used tbnz there, but it turns out that tbnz does *not* set the zero flag, but we do need the ZF set correctly on exit of fast_unlock, so that C2 generated code would actually call the slow path. Therefore we need to use the longer tst/br instructions instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300566](https://bugs.openjdk.org/browse/JDK-8300566): [Lilliput/JDK17] Properly set ZF on anon-check path


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u pull/4/head:pull/4` \
`$ git checkout pull/4`

Update a local copy of the PR: \
`$ git checkout pull/4` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u pull/4/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4`

View PR using the GUI difftool: \
`$ git pr show -t 4`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/4.diff">https://git.openjdk.org/lilliput-jdk17u/pull/4.diff</a>

</details>
