### PR TITLE
8304329: [Lilliput/JDK17] Fix DiagnoseSyncOnValueBasedClasses

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -2080,7 +2080,7 @@ void ClassFileParser::ClassAnnotationCollector::apply_to(InstanceKlass* ik) {
     if (DiagnoseSyncOnValueBasedClasses) {
       ik->set_is_value_based();
       if (UseCompactObjectHeaders) {
-        ik->set_prototype_header(markWord::prototype().set_klass(ik));
+        ik->set_prototype_header(markWord::prototype() LP64_ONLY(.set_klass(ik)));
       } else {
         ik->set_prototype_header(markWord::prototype());
       }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -2079,7 +2079,11 @@ void ClassFileParser::ClassAnnotationCollector::apply_to(InstanceKlass* ik) {
     ik->set_has_value_based_class_annotation();
     if (DiagnoseSyncOnValueBasedClasses) {
       ik->set_is_value_based();
-      ik->set_prototype_header(markWord::prototype());
+      markWord prototype = markWord::prototype();
+      if (UseCompactObjectHeaders) {
+        prototype = prototype.set_klass(ik);
+      }
+      ik->set_prototype_header(prototype);
     }
   }
 }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -2079,11 +2079,11 @@ void ClassFileParser::ClassAnnotationCollector::apply_to(InstanceKlass* ik) {
     ik->set_has_value_based_class_annotation();
     if (DiagnoseSyncOnValueBasedClasses) {
       ik->set_is_value_based();
-      markWord prototype = markWord::prototype();
       if (UseCompactObjectHeaders) {
-        prototype = prototype.set_klass(ik);
+        ik->set_prototype_header(markWord::prototype().set_klass(ik));
+      } else {
+        ik->set_prototype_header(markWord::prototype());
       }
-      ik->set_prototype_header(prototype);
     }
   }
 }


### PR DESCRIPTION
Some deeper testing shows that the following test is currently failing in Lilliput/JDK17:

java/net/httpclient/LineBodyHandlerTest.java

That is caused by that test using DiagnoseSyncOnValueBasedClasses, and that seems currently broken with Lilliput/JDK17 because it sets a plain prototype header on a class, where it should also set the narrow Klass* in the prototype.

Testing:
 - [x] java/net/httpclient/LineBodyHandlerTest.java
 - [x] tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304329](https://bugs.openjdk.org/browse/JDK-8304329): [Lilliput/JDK17] Fix DiagnoseSyncOnValueBasedClasses


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [351caa8c](https://git.openjdk.org/lilliput-jdk17u/pull/11/files/351caa8c64847f321d9c7e3d37f5caa0b582aca1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/11.diff">https://git.openjdk.org/lilliput-jdk17u/pull/11.diff</a>

</details>
