### PR TITLE
8304331: [Lilliput/JDK17] Fix RTM locking

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -728,7 +728,7 @@ void C2_MacroAssembler::fast_unlock(Register objReg, Register boxReg, Register t
     testptr(boxReg, boxReg);
     jccb(Assembler::notZero, L_regular_inflated_unlock);
     xend();
-    jmpb(DONE_LABEL);
+    jmp(DONE_LABEL);
     bind(L_regular_inflated_unlock);
   }
 #endif

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -179,3 +179,5 @@ gc/arguments/TestCompressedClassFlags.java 1234567 generic-all
 
 # Dispabled because Lilliput forces -UseBiasedLocking
 runtime/logging/BiasedLockingTest.java 1234567 generic-all
+# Because of -UseBiasedLocking, too
+compiler/rtm/cli/TestUseRTMLockingOptionWithBiasedLocking.java 8304331 generic-x64,generic-i586

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -177,7 +177,7 @@ vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEa
 # Disabled because Lilliput forces +UseCompressedClassPointers
 gc/arguments/TestCompressedClassFlags.java 1234567 generic-all
 
-# Dispabled because Lilliput forces -UseBiasedLocking
+# Disabled because Lilliput forces -UseBiasedLocking
 runtime/logging/BiasedLockingTest.java 1234567 generic-all
 # Because of -UseBiasedLocking, too
 compiler/rtm/cli/TestUseRTMLockingOptionWithBiasedLocking.java 8304331 generic-x64,generic-i586

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -180,4 +180,4 @@ gc/arguments/TestCompressedClassFlags.java 1234567 generic-all
 # Disabled because Lilliput forces -UseBiasedLocking
 runtime/logging/BiasedLockingTest.java 1234567 generic-all
 # Because of -UseBiasedLocking, too
-compiler/rtm/cli/TestUseRTMLockingOptionWithBiasedLocking.java 8304331 generic-x64,generic-i586
+compiler/rtm/cli/TestUseRTMLockingOptionWithBiasedLocking.java 1234567 generic-x64,generic-i586


### PR DESCRIPTION
Some RTM locking tests are currently failing:

compiler/rtm/cli/TestUseRTMLockingOptionWithBiasedLocking.java
compiler/rtm/locking/TestRTMRetryCount.java
compiler/rtm/locking/TestRTMTotalCountIncrRate.java
compiler/rtm/locking/TestUseRTMAfterLockInflation.java
compiler/rtm/locking/TestUseRTMForInflatedLocks.java
compiler/rtm/locking/TestUseRTMForStackLocks.java
compiler/rtm/method_options/TestUseRTMLockElidingOption.java

Most are because there's a jmpb in UseRTMLocking parts that fails because of longer locking code with Lilliput. One test is failing because it checks a warning message when somebody tries +UseBiasedLocking together with RTM locking, but Lilliput forces biased locking to be off, so the warning never appears. I problem-listed that test.

Testing:
 - [x] all tests listed above

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304331](https://bugs.openjdk.org/browse/JDK-8304331): [Lilliput/JDK17] Fix RTM locking


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [45a345b8](https://git.openjdk.org/lilliput-jdk17u/pull/12/files/45a345b8a71828945923aca170cdbac93d39029b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/12.diff">https://git.openjdk.org/lilliput-jdk17u/pull/12.diff</a>

</details>
