### PR TITLE
8304410: [Lilliput/JDK17] Remove unneeded code in ContiguousSpace::object_iterate_from()

### DIFF
--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -486,11 +486,6 @@ void ContiguousSpace::object_iterate_from(HeapWord* mark, ObjectClosure* blk) {
   while (mark < top()) {
     blk->do_object(cast_to_oop(mark));
     oop obj = cast_to_oop(mark);
-#ifdef _LP64
-    if (obj->is_forwarded() && CompressedKlassPointers::is_null(obj->mark().narrow_klass())) {
-      obj = obj->forwardee();
-    }
-#endif
     mark += obj->size();
   }
 }


### PR DESCRIPTION
There is some code in space.cpp that resolves a forwarding pointer to get to the Klass* of an object under Lilliput, but it is not necessary and actually causes harm (the null-check doesn't really make sense when the object is indeed forwarded, but we should not observe a forwarded object to begin with). It is not in upstream JDK(21) version of Lilliput and removing it causes no harm.

Testing:
 - [x] tier1 -XX:+UseCompactHeaders
 - [x] tier1 -XX:-UseCompactHeaders
 - [x] tier2 -XX:+UseCompactHeaders
 - [x] tier2 -XX:-UseCompactHeaders