### PR TITLE
8308172: [Lilliput/JDK17] Revert disabling vzeroupper

### DIFF
--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -344,7 +344,7 @@ class LibraryCallKit : public GraphKit {
 
   void clear_upper_avx() {
 #ifdef X86
-    if (false && UseAVX >= 2) {
+    if (UseAVX >= 2) {
       C->set_clear_upper_avx(true);
     }
 #endif


### PR DESCRIPTION
While looking through the diff between Lilliput/JDK17 and upstream JDK17, I noticed one change in library_call.cpp that should not be there, it probably slipped through from debugging.

    void clear_upper_avx() {
  #ifdef X86
- if (UseAVX >= 2) {
+ if (false && UseAVX >= 2) {
        C->set_clear_upper_avx(true);
      }
  #endif
    }

This prevents emitting vzeroupper instructions on x86_64. I believe this will have performance impact when transitioning between AVX and SSE code. We should revert this.