### PR TITLE
8308107: [Lilliput/JDK17] Cherry-pick: 8291555: Implement alternative fast-locking scheme

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1912,18 +1912,6 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   __ build_frame(framesize);
 
-  int max_monitors = C->method() != NULL ? C->max_monitors() : 0;
-  if (UseFastLocking && max_monitors > 0) {
-    C2CheckLockStackStub* stub = new (C->comp_arena()) C2CheckLockStackStub();
-    C->output()->add_stub(stub);
-    __ ldr(r9, Address(rthread, JavaThread::lock_stack_current_offset()));
-    __ add(r9, r9, max_monitors * oopSize);
-    __ ldr(r10, Address(rthread, JavaThread::lock_stack_limit_offset()));
-    __ cmp(r9, r10);
-    __ br(Assembler::GE, stub->entry());
-    __ bind(stub->continuation());
-  }
-
   if (C->stub_function() == NULL) {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
     bs->nmethod_entry_barrier(&_masm);
@@ -3842,11 +3830,10 @@ encode %{
     // Check for existing monitor
     __ tbnz(disp_hdr, exact_log2(markWord::monitor_value), object_has_monitor);
 
-    if (UseFastLocking) {
-      __ fast_lock(oop, disp_hdr, tmp, rscratch1, cont, false);
-      // Indicate success at cont.
-      __ cmp(oop, oop);
-    } else {
+    if (LockingMode == LM_MONITOR) {
+      __ tst(oop, oop); // Set NE to indicate 'failure' -> take slow-path. We know that oop != 0.
+      __ b(cont);
+    } else if (LockingMode == LM_LEGACY) {
       // Set tmp to be (markWord of object | UNLOCK_VALUE).
       __ orr(tmp, disp_hdr, markWord::unlocked_value);
 
@@ -3877,8 +3864,12 @@ encode %{
       // displaced header in the box, which indicates that it is a recursive lock.
       __ ands(tmp/*==0?*/, disp_hdr, tmp);   // Sets flags for result
       __ str(tmp/*==0, perhaps*/, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+      __ b(cont);
+    } else {
+      assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+      __ fast_lock(oop, disp_hdr, tmp, rscratch1, cont);
+      __ b(cont);
     }
-    __ b(cont);
 
     // Handle existing monitor.
     __ bind(object_has_monitor);
@@ -3891,7 +3882,7 @@ encode %{
     __ cmpxchg(tmp, zr, rthread, Assembler::xword, /*acquire*/ true,
                /*release*/ true, /*weak*/ false, rscratch1); // Sets flags for result
 
-    if (!UseFastLocking) {
+    if (LockingMode != LM_LIGHTWEIGHT) {
       // Store a non-null value into the box to avoid looking like a re-entrant
       // lock. The fast-path monitor unlock code checks for
       // markWord::monitor_value so use markWord::unused_mark which has the
@@ -3928,7 +3919,7 @@ encode %{
       __ biased_locking_exit(oop, tmp, cont);
     }
 
-    if (!UseFastLocking) {
+    if (LockingMode == LM_LEGACY) {
       // Find the lock address and load the displaced header from the stack.
       __ ldr(disp_hdr, Address(box, BasicLock::displaced_header_offset_in_bytes()));
 
@@ -3941,20 +3932,23 @@ encode %{
     __ ldr(tmp, Address(oop, oopDesc::mark_offset_in_bytes()));
     __ tbnz(tmp, exact_log2(markWord::monitor_value), object_has_monitor);
 
-
-    if (UseFastLocking) {
-      __ fast_unlock(oop, tmp, box, disp_hdr, cont);
-      // Indicate success at cont.
-      __ cmp(oop, oop);
-    } else {
+    if (LockingMode == LM_MONITOR) {
+      __ tst(oop, oop); // Set NE to indicate 'failure' -> take slow-path. We know that oop != 0.
+      __ b(cont);
+    } else if (LockingMode == LM_LEGACY) {
       // Check if it is still a light weight lock, this is is true if we
       // see the stack address of the basicLock in the markWord of the
       // object.
 
       __ cmpxchg(oop, box, disp_hdr, Assembler::xword, /*acquire*/ false,
                  /*release*/ true, /*weak*/ false, tmp);
+      __ b(cont);
+    } else {
+      assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+      __ fast_unlock(oop, tmp, box, disp_hdr, cont);
+      __ b(cont);
     }
-    __ b(cont);
+
     assert(oopDesc::mark_offset_in_bytes() == 0, "offset of _mark is not 0");
 
     // Handle existing monitor.
@@ -3962,13 +3956,13 @@ encode %{
     STATIC_ASSERT(markWord::monitor_value <= INT_MAX);
     __ add(tmp, tmp, -(int)markWord::monitor_value); // monitor
 
-    if (UseFastLocking) {
+    if (LockingMode == LM_LIGHTWEIGHT) {
       // If the owner is anonymous, we need to fix it -- in an outline stub.
       Register tmp2 = disp_hdr;
       __ ldr(tmp2, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
       // We cannot use tbnz here, the target might be too far away and cannot
       // be encoded.
-      __ tst(tmp2, (uint64_t)(intptr_t) ANONYMOUS_OWNER);
+      __ tst(tmp2, (uint64_t)ObjectMonitor::ANONYMOUS_OWNER);
       C2HandleAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2HandleAnonOMOwnerStub(tmp, tmp2);
       Compile::current()->output()->add_stub(stub);
       __ br(Assembler::NE, stub->entry());

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -242,7 +242,7 @@ void LIR_Assembler::osr_entry() {
 
   // build frame
   ciMethod* m = compilation()->method();
-  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes(), compilation()->max_monitors());
+  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes());
 
   // OSR buffer is
   //
@@ -2539,7 +2539,7 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   Register obj = op->obj_opr()->as_register();  // may not be an oop
   Register hdr = op->hdr_opr()->as_register();
   Register lock = op->lock_opr()->as_register();
-  if (UseHeavyMonitors) {
+  if (LockingMode == LM_MONITOR) {
     if (op->info() != NULL) {
       add_debug_info_for_null_check_here(op->info());
       __ null_check(obj, -1);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5410,23 +5410,21 @@ void MacroAssembler::spin_wait() {
   }
 }
 
-// Attempt to fast-lock an object. Fall-through on success, branch to slow label
-// on failure.
-// Registers:
+// Implements fast-locking.
+// Branches to slow upon failure to lock the object, with ZF cleared.
+// Falls through upon success with ZF set.
+//
 //  - obj: the object to be locked
 //  - hdr: the header, already loaded from obj, will be destroyed
-//  - t1, t2, t3: temporary registers, will be destroyed
-void MacroAssembler::fast_lock(Register obj, Register hdr, Register t1, Register t2, Label& slow, bool rt_check_stack) {
-  assert(UseFastLocking, "only used with fast-locking");
+//  - t1, t2: temporary registers, will be destroyed
+void MacroAssembler::fast_lock(Register obj, Register hdr, Register t1, Register t2, Label& slow) {
+  assert(LockingMode == LM_LIGHTWEIGHT, "only used with new lightweight locking");
   assert_different_registers(obj, hdr, t1, t2);
 
-  if (rt_check_stack) {
-    // Check if we would have space on lock-stack for the object.
-    ldr(t1, Address(rthread, JavaThread::lock_stack_current_offset()));
-    ldr(t2, Address(rthread, JavaThread::lock_stack_limit_offset()));
-    cmp(t1, t2);
-    br(Assembler::GE, slow);
-  }
+  // Check if we would have space on lock-stack for the object.
+  ldrw(t1, Address(rthread, JavaThread::lock_stack_top_offset()));
+  cmpw(t1, (unsigned)LockStack::end_offset() - 1);
+  br(Assembler::GT, slow);
 
   // Load (object->mark() | 1) into hdr
   orr(hdr, hdr, markWord::unlocked_value);
@@ -5438,18 +5436,56 @@ void MacroAssembler::fast_lock(Register obj, Register hdr, Register t1, Register
   br(Assembler::NE, slow);
 
   // After successful lock, push object on lock-stack
-  ldr(t1, Address(rthread, JavaThread::lock_stack_current_offset()));
-  str(obj, Address(t1, 0));
-  add(t1, t1, oopSize);
-  str(t1, Address(rthread, JavaThread::lock_stack_current_offset()));
+  ldrw(t1, Address(rthread, JavaThread::lock_stack_top_offset()));
+  str(obj, Address(rthread, t1));
+  addw(t1, t1, oopSize);
+  strw(t1, Address(rthread, JavaThread::lock_stack_top_offset()));
 }
 
+// Implements fast-unlocking.
+// Branches to slow upon failure, with ZF cleared.
+// Falls through upon success, with ZF set.
+//
+// - obj: the object to be unlocked
+// - hdr: the (pre-loaded) header of the object
+// - t1, t2: temporary registers
 void MacroAssembler::fast_unlock(Register obj, Register hdr, Register t1, Register t2, Label& slow) {
-  assert(UseFastLocking, "only used with fast-locking");
+  assert(LockingMode == LM_LIGHTWEIGHT, "only used with new lightweight locking");
   assert_different_registers(obj, hdr, t1, t2);
 
-  // Load the expected old header (lock-bits cleared to indicate 'locked') into hdr
-  andr(hdr, hdr, ~markWord::lock_mask_in_place);
+#ifdef ASSERT
+  {
+    // The following checks rely on the fact that LockStack is only ever modified by
+    // its owning thread, even if the lock got inflated concurrently; removal of LockStack
+    // entries after inflation will happen delayed in that case.
+
+    // Check for lock-stack underflow.
+    Label stack_ok;
+    ldrw(t1, Address(rthread, JavaThread::lock_stack_top_offset()));
+    cmpw(t1, (unsigned)LockStack::start_offset());
+    br(Assembler::GT, stack_ok);
+    STOP("Lock-stack underflow");
+    bind(stack_ok);
+  }
+  {
+    // Check if the top of the lock-stack matches the unlocked object.
+    Label tos_ok;
+    subw(t1, t1, oopSize);
+    ldr(t1, Address(rthread, t1));
+    cmpoop(t1, obj);
+    br(Assembler::EQ, tos_ok);
+    STOP("Top of lock-stack does not match the unlocked object");
+    bind(tos_ok);
+  }
+  {
+    // Check that hdr is fast-locked.
+    Label hdr_ok;
+    tst(hdr, markWord::lock_mask_in_place);
+    br(Assembler::EQ, hdr_ok);
+    STOP("Header is not fast-locked");
+    bind(hdr_ok);
+  }
+#endif
 
   // Load the new header (unlocked) into t1
   orr(t1, hdr, markWord::unlocked_value);
@@ -5460,7 +5496,10 @@ void MacroAssembler::fast_unlock(Register obj, Register hdr, Register t1, Regist
   br(Assembler::NE, slow);
 
   // After successful unlock, pop object from lock-stack
-  ldr(t1, Address(rthread, JavaThread::lock_stack_current_offset()));
-  sub(t1, t1, oopSize);
-  str(t1, Address(rthread, JavaThread::lock_stack_current_offset()));
+  ldrw(t1, Address(rthread, JavaThread::lock_stack_top_offset()));
+  subw(t1, t1, oopSize);
+#ifdef ASSERT
+  str(zr, Address(rthread, t1));
+#endif
+  strw(t1, Address(rthread, JavaThread::lock_stack_top_offset()));
 }

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1421,7 +1421,7 @@ public:
   // Code for java.lang.Thread::onSpinWait() intrinsic.
   void spin_wait();
 
-  void fast_lock(Register obj, Register hdr, Register t1, Register t2, Label& slow, bool rt_check_stack = true);
+  void fast_lock(Register obj, Register hdr, Register t1, Register t2, Label& slow);
   void fast_unlock(Register obj, Register hdr, Register t1, Register t2, Label& slow);
 
 private:

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -5291,29 +5291,6 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
-  address generate_check_lock_stack() {
-    __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, "StubRoutines", "check_lock_stack");
-
-    address start = __ pc();
-
-    __ set_last_Java_frame(sp, rfp, lr, rscratch1);
-    __ enter();
-    __ push_call_clobbered_registers();
-
-    __ mov(c_rarg0, r9);
-    __ call_VM_leaf(CAST_FROM_FN_PTR(address, LockStack::ensure_lock_stack_size), 1);
-
-
-    __ pop_call_clobbered_registers();
-    __ leave();
-    __ reset_last_Java_frame(true);
-
-    __ ret(lr);
-
-    return start;
-  }
-
   // r0  = result
   // r1  = str1
   // r2  = cnt1
@@ -7621,9 +7598,6 @@ class StubGenerator: public StubCodeGenerator {
     BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
     if (bs_nm != NULL) {
       StubRoutines::aarch64::_method_entry_barrier = generate_method_entry_barrier();
-    }
-    if (UseFastLocking) {
-      StubRoutines::aarch64::_check_lock_stack = generate_check_lock_stack();
     }
 #ifdef COMPILER2
     if (UseMultiplyToLenIntrinsic) {

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
@@ -57,7 +57,6 @@ address StubRoutines::aarch64::_string_indexof_linear_uu = NULL;
 address StubRoutines::aarch64::_string_indexof_linear_ul = NULL;
 address StubRoutines::aarch64::_large_byte_array_inflate = NULL;
 address StubRoutines::aarch64::_method_entry_barrier = NULL;
-address StubRoutines::aarch64::_check_lock_stack = NULL;
 
 static void empty_spin_wait() { }
 address StubRoutines::aarch64::_spin_wait = CAST_FROM_FN_PTR(address, empty_spin_wait);

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
@@ -72,8 +72,6 @@ class aarch64 {
 
   static address _method_entry_barrier;
 
-  static address _check_lock_stack;
-
   static address _spin_wait;
 
   static bool _completed;
@@ -179,10 +177,6 @@ class aarch64 {
 
   static address method_entry_barrier() {
     return _method_entry_barrier;
-  }
-
-  static address check_lock_stack() {
-    return _check_lock_stack;
   }
 
   static address spin_wait() {

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -285,7 +285,7 @@ void LIR_Assembler::osr_entry() {
 
   // build frame
   ciMethod* m = compilation()->method();
-  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes(), compilation()->max_monitors());
+  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes());
 
   // OSR buffer is
   //
@@ -3488,11 +3488,11 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   Register obj = op->obj_opr()->as_register();  // may not be an oop
   Register hdr = op->hdr_opr()->as_register();
   Register lock = op->lock_opr()->as_register();
-  if (UseHeavyMonitors) {
+  if (LockingMode == LM_MONITOR) {
     __ jmp(*op->stub()->entry());
   } else if (op->code() == lir_lock) {
     Register scratch = noreg;
-    if (UseBiasedLocking || UseFastLocking) {
+    if (UseBiasedLocking || LockingMode == LM_LIGHTWEIGHT) {
       scratch = op->scratch_opr()->as_register();
     }
     assert(BasicLock::displaced_header_offset_in_bytes() == 0, "lock_reg must point to the displaced header");

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -314,7 +314,7 @@ void LIRGenerator::do_MonitorEnter(MonitorEnter* x) {
   LIR_Opr lock = new_register(T_INT);
   // Need a scratch register for biased locking on x86
   LIR_Opr scratch = LIR_OprFact::illegalOpr;
-  if (UseBiasedLocking || UseFastLocking) {
+  if (UseBiasedLocking || LockingMode == LM_LIGHTWEIGHT) {
     scratch = new_register(T_INT);
   }
 

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -60,7 +60,7 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
     jcc(Assembler::notZero, slow_case);
   }
 
-  if (UseFastLocking) {
+  if (LockingMode == LM_LIGHTWEIGHT) {
 #ifdef _LP64
     const Register thread = r15_thread;
 #else
@@ -69,7 +69,7 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
 #endif
     // Load object header
     movptr(hdr, Address(obj, hdr_offset));
-    fast_lock_impl(obj, hdr, thread, scratch, slow_case, LP64_ONLY(false) NOT_LP64(true));
+    fast_lock_impl(obj, hdr, thread, scratch, slow_case);
   } else {
     Label done;
 
@@ -128,7 +128,7 @@ void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register disp_
   assert(disp_hdr == rax, "disp_hdr must be rax, for the cmpxchg instruction");
   assert(hdr != obj && hdr != disp_hdr && obj != disp_hdr, "registers must be different");
 
-  if (UseFastLocking) {
+  if (LockingMode == LM_LIGHTWEIGHT) {
     // load object
     movptr(obj, Address(disp_hdr, BasicObjectLock::obj_offset_in_bytes()));
     verify_oop(obj);
@@ -167,6 +167,7 @@ void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register disp_
     bind(done);
   }
 }
+
 
 // Defines obj, preserves var_size_in_bytes
 void C1_MacroAssembler::try_allocate(Register obj, Register var_size_in_bytes, int con_size_in_bytes, Register t1, Register t2, Label& slow_case) {
@@ -341,7 +342,7 @@ void C1_MacroAssembler::inline_cache_check(Register receiver, Register iCache) {
 }
 
 
-void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_bytes, int max_monitors) {
+void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_bytes) {
   assert(bang_size_in_bytes >= frame_size_in_bytes, "stack bang size incorrect");
   // Make sure there is enough stack space for this method's activation.
   // Note that we do this before doing an enter(). This matches the
@@ -361,19 +362,6 @@ void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_by
   }
 #endif // !_LP64 && COMPILER2
   decrement(rsp, frame_size_in_bytes); // does not emit code for frame_size == 0
-
-#ifdef _LP64
-  if (UseFastLocking && max_monitors > 0) {
-    Label ok;
-    movptr(rax, Address(r15_thread, JavaThread::lock_stack_current_offset()));
-    addptr(rax, max_monitors * wordSize);
-    cmpptr(rax, Address(r15_thread, JavaThread::lock_stack_limit_offset()));
-    jcc(Assembler::less, ok);
-    assert(StubRoutines::x86::check_lock_stack() != NULL, "need runtime call stub");
-    call(RuntimeAddress(StubRoutines::x86::check_lock_stack()));
-    bind(ok);
-  }
-#endif
 
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
   bs->nmethod_entry_barrier(this);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -515,7 +515,7 @@ void C2_MacroAssembler::fast_lock(Register objReg, Register boxReg, Register tmp
 
   movptr(tmpReg, Address(objReg, oopDesc::mark_offset_in_bytes()));          // [FETCH]
   testptr(tmpReg, markWord::monitor_value); // inflated vs stack-locked|neutral|biased
-  jccb(Assembler::notZero, IsInflated);
+  jcc(Assembler::notZero, IsInflated);
 
   if (LockingMode == LM_MONITOR) {
     // Clear ZF so that we take the slow path at the DONE label. objReg is known to be not 0.
@@ -708,7 +708,7 @@ void C2_MacroAssembler::fast_unlock(Register objReg, Register boxReg, Register t
   // It's inflated.
   if (LockingMode == LM_LIGHTWEIGHT) {
     // If the owner is ANONYMOUS, we need to fix it.
-    testb(Address(tmpReg, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), (int) (intptr_t) ObjectMonitor::ANONYMOUS_OWNER);
+    testb(Address(tmpReg, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), (int32_t) ObjectMonitor::ANONYMOUS_OWNER);
 #ifdef _LP64
     if (!Compile::current()->output()->in_scratch_emit_size()) {
       C2HandleAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2HandleAnonOMOwnerStub(tmpReg, boxReg);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -517,23 +517,10 @@ void C2_MacroAssembler::fast_lock(Register objReg, Register boxReg, Register tmp
   testptr(tmpReg, markWord::monitor_value); // inflated vs stack-locked|neutral|biased
   jccb(Assembler::notZero, IsInflated);
 
-  if (UseFastLocking) {
-#ifdef _LP64
-    fast_lock_impl(objReg, tmpReg, thread, scrReg, DONE_LABEL, false);
-    xorl(tmpReg, tmpReg); // Set ZF=1 to indicate success
-#else
-    // We can not emit the lock-stack-check in verified_entry() because we don't have enough
-    // registers (for thread ptr). Therefor we have to emit the lock-stack-check in
-    // fast_lock_impl(). However, that check can take a slow-path with ZF=1, therefore
-    // we need to handle it specially and force ZF=0 before taking the actual slow-path.
-    Label slow;
-    fast_lock_impl(objReg, tmpReg, thread, scrReg, slow);
-    xorl(tmpReg, tmpReg);
-    jmp(DONE_LABEL);
-    bind(slow);
-    testptr(objReg, objReg); // ZF=0 to indicate failure
-#endif
-  } else {
+  if (LockingMode == LM_MONITOR) {
+    // Clear ZF so that we take the slow path at the DONE label. objReg is known to be not 0.
+    testptr(objReg, objReg);
+  } else if (LockingMode == LM_LEGACY) {
     // Attempt stack-locking ...
     orptr (tmpReg, markWord::unlocked_value);
     movptr(Address(boxReg, 0), tmpReg);          // Anticipate successful CAS
@@ -556,6 +543,10 @@ void C2_MacroAssembler::fast_lock(Register objReg, Register boxReg, Register tmp
       cond_inc32(Assembler::equal,
                  ExternalAddress((address)counters->fast_path_entry_count_addr()));
     }
+  } else {
+    assert(LockingMode == LM_LIGHTWEIGHT, "");
+    fast_lock_impl(objReg, tmpReg, thread, scrReg, DONE_LABEL);
+    xorl(tmpReg, tmpReg); // Set ZF=1 to indicate success
   }
   jmp(DONE_LABEL);
 
@@ -596,8 +587,16 @@ void C2_MacroAssembler::fast_lock(Register objReg, Register boxReg, Register tmp
   // (rsp or the address of the box) into  m->owner is harmless.
   // Invariant: tmpReg == 0.  tmpReg is EAX which is the implicit cmpxchg comparand.
   lock();
-  cmpxchgptr(thread, Address(boxReg, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)));
+  cmpxchgptr(scrReg, Address(boxReg, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)));
   movptr(Address(scrReg, 0), 3);          // box->_displaced_header = 3
+  // If we weren't able to swing _owner from NULL to the BasicLock
+  // then take the slow path.
+  jccb  (Assembler::notZero, DONE_LABEL);
+  // update _owner from BasicLock to thread
+  get_thread (scrReg);                    // beware: clobbers ICCs
+  movptr(Address(boxReg, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), scrReg);
+  xorptr(boxReg, boxReg);                 // set icc.ZFlag = 1 to indicate success
+
   // If the CAS fails we can either retry or pass control to the slow path.
   // We use the latter tactic.
   // Pass the CAS result in the icc.ZFlag into DONE_LABEL
@@ -696,30 +695,35 @@ void C2_MacroAssembler::fast_unlock(Register objReg, Register boxReg, Register t
   }
 #endif
 
-  if (!UseFastLocking) {
+  if (LockingMode == LM_LEGACY) {
     cmpptr(Address(boxReg, 0), (int32_t)NULL_WORD);                   // Examine the displaced header
     jcc   (Assembler::zero, DONE_LABEL);                              // 0 indicates recursive stack-lock
   }
   movptr(tmpReg, Address(objReg, oopDesc::mark_offset_in_bytes())); // Examine the object's markword
-  testptr(tmpReg, markWord::monitor_value);                         // Inflated?
-  jcc(Assembler::zero, Stacked);
-
-  if (UseFastLocking) {
-    // If the owner is ANONYMOUS, we need to fix it.
-    testb(Address(tmpReg, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), (int) (intptr_t) ANONYMOUS_OWNER);
-#ifdef _LP64
-    C2HandleAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2HandleAnonOMOwnerStub(tmpReg);
-    Compile::current()->output()->add_stub(stub);
-    jcc(Assembler::notEqual, stub->entry());
-    bind(stub->continuation());
-#else
-    // We can't easily implement this optimization on 32 bit because we don't have a thread register.
-    // Call the slow-path instead.
-    jcc(Assembler::notEqual, DONE_LABEL);
-#endif
+  if (LockingMode != LM_MONITOR) {
+    testptr(tmpReg, markWord::monitor_value);                         // Inflated?
+    jcc(Assembler::zero, Stacked);
   }
 
   // It's inflated.
+  if (LockingMode == LM_LIGHTWEIGHT) {
+    // If the owner is ANONYMOUS, we need to fix it.
+    testb(Address(tmpReg, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), (int) (intptr_t) ObjectMonitor::ANONYMOUS_OWNER);
+#ifdef _LP64
+    if (!Compile::current()->output()->in_scratch_emit_size()) {
+      C2HandleAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2HandleAnonOMOwnerStub(tmpReg, boxReg);
+      Compile::current()->output()->add_stub(stub);
+      jcc(Assembler::notEqual, stub->entry());
+      bind(stub->continuation());
+    } else
+#endif
+    {
+      // We can't easily implement this optimization on 32 bit because we don't have a thread register.
+      // Call the slow-path instead.
+      jcc(Assembler::notEqual, DONE_LABEL);
+    }
+  }
+
 #if INCLUDE_RTM_OPT
   if (use_rtm) {
     Label L_regular_inflated_unlock;
@@ -767,20 +771,22 @@ void C2_MacroAssembler::fast_unlock(Register objReg, Register boxReg, Register t
   movptr(Address(tmpReg, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), NULL_WORD);
   jmpb  (DONE_LABEL);
 
-  bind (Stacked);
-  if (UseFastLocking) {
-    mov(boxReg, tmpReg);
-    fast_unlock_impl(objReg, boxReg, tmpReg, DONE_LABEL);
-    xorl(tmpReg, tmpReg);
-  } else {
-    // It's not inflated and it's not recursively stack-locked and it's not biased.
-    // It must be stack-locked.
-    // Try to reset the header to displaced header.
-    // The "box" value on the stack is stable, so we can reload
-    // and be assured we observe the same value as above.
-    movptr(tmpReg, Address(boxReg, 0));
-    lock();
-    cmpxchgptr(tmpReg, Address(objReg, oopDesc::mark_offset_in_bytes())); // Uses RAX which is box
+  if (LockingMode != LM_MONITOR) {
+    bind (Stacked);
+    if (LockingMode == LM_LIGHTWEIGHT) {
+      mov(boxReg, tmpReg);
+      fast_unlock_impl(objReg, boxReg, tmpReg, DONE_LABEL);
+      xorl(tmpReg, tmpReg);
+    } else if (LockingMode == LM_LEGACY) {
+      // It's not inflated and it's not recursively stack-locked and it's not biased.
+      // It must be stack-locked.
+      // Try to reset the header to displaced header.
+      // The "box" value on the stack is stable, so we can reload
+      // and be assured we observe the same value as above.
+      movptr(tmpReg, Address(boxReg, 0));
+      lock();
+      cmpxchgptr(tmpReg, Address(objReg, oopDesc::mark_offset_in_bytes())); // Uses RAX which is box
+    }
   }
   // Intention fall-thru into DONE_LABEL
 
@@ -865,19 +871,19 @@ void C2_MacroAssembler::fast_unlock(Register objReg, Register boxReg, Register t
   testl (boxReg, 0);                      // set ICC.ZF=1 to indicate success
   jmpb  (DONE_LABEL);
 
-  bind  (Stacked);
-
-  if (UseFastLocking) {
-    mov(boxReg, tmpReg);
-    fast_unlock_impl(objReg, boxReg, tmpReg, DONE_LABEL);
-    xorl(tmpReg, tmpReg);
-  } else {
-    movptr(tmpReg, Address (boxReg, 0));      // re-fetch
-    lock();
-    cmpxchgptr(tmpReg, Address(objReg, oopDesc::mark_offset_in_bytes())); // Uses RAX which is box
-  }
-
 #endif
+  if (LockingMode != LM_MONITOR) {
+    bind  (Stacked);
+    if (LockingMode == LM_LIGHTWEIGHT) {
+      mov(boxReg, tmpReg);
+      fast_unlock_impl(objReg, boxReg, tmpReg, DONE_LABEL);
+      xorl(tmpReg, tmpReg);
+    } else {
+      movptr(tmpReg, Address (boxReg, 0));      // re-fetch
+      lock();
+      cmpxchgptr(tmpReg, Address(objReg, oopDesc::mark_offset_in_bytes())); // Uses RAX which is box
+    }
+  }
   bind(DONE_LABEL);
 }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5206,7 +5206,7 @@ void MacroAssembler::reinit_heapbase() {
 #endif // _LP64
 
 // C2 compiled method's prolog code.
-void MacroAssembler::verified_entry(int framesize, int stack_bang_size, bool fp_mode_24b, bool is_stub, int max_monitors) {
+void MacroAssembler::verified_entry(int framesize, int stack_bang_size, bool fp_mode_24b, bool is_stub) {
 
   // WARNING: Initial instruction MUST be 5 bytes or longer so that
   // NativeJump::patch_verified_entry will be able to patch out the entry
@@ -5285,20 +5285,6 @@ void MacroAssembler::verified_entry(int framesize, int stack_bang_size, bool fp_
     jcc(Assembler::equal, L);
     STOP("Stack is not properly aligned!");
     bind(L);
-  }
-#endif
-
-#if defined(_LP64) && defined(COMPILER2)
-  if (UseFastLocking && max_monitors > 0) {
-    C2CheckLockStackStub* stub = new (Compile::current()->comp_arena()) C2CheckLockStackStub();
-    Compile::current()->output()->add_stub(stub);
-    assert(!is_stub, "only methods have monitors");
-    Register thread = r15_thread;
-    movptr(rax, Address(thread, JavaThread::lock_stack_current_offset()));
-    addptr(rax, max_monitors * wordSize);
-    cmpptr(rax, Address(thread, JavaThread::lock_stack_limit_offset()));
-    jcc(Assembler::greaterEqual, stub->entry());
-    bind(stub->continuation());
   }
 #endif
 
@@ -8785,49 +8771,54 @@ void MacroAssembler::get_thread(Register thread) {
 
 #endif // !WIN32 || _LP64
 
-void MacroAssembler::fast_lock_impl(Register obj, Register hdr, Register thread, Register tmp, Label& slow, bool rt_check_stack) {
+// Implements fast-locking.
+// Branches to slow upon failure to lock the object, with ZF cleared.
+// Falls through upon success with unspecified ZF.
+//
+// obj: the object to be locked
+// hdr: the (pre-loaded) header of the object, must be rax
+// thread: the thread which attempts to lock obj
+// tmp: a temporary register
+void MacroAssembler::fast_lock_impl(Register obj, Register hdr, Register thread, Register tmp, Label& slow) {
   assert(hdr == rax, "header must be in rax for cmpxchg");
   assert_different_registers(obj, hdr, thread, tmp);
 
   // First we need to check if the lock-stack has room for pushing the object reference.
-  if (rt_check_stack) {
-    movptr(tmp, Address(thread, JavaThread::lock_stack_current_offset()));
-    cmpptr(tmp, Address(thread, JavaThread::lock_stack_limit_offset()));
-    jcc(Assembler::greaterEqual, slow);
-  }
-#ifdef ASSERT
-  else {
-    Label ok;
-    movptr(tmp, Address(thread, JavaThread::lock_stack_current_offset()));
-    cmpptr(tmp, Address(thread, JavaThread::lock_stack_limit_offset()));
-    jcc(Assembler::less, ok);
-    stop("Not enough room in lock stack; should have been checked in the method prologue");
-    bind(ok);
-  }
-#endif
+  // Note: we subtract 1 from the end-offset so that we can do a 'greater' comparison, instead
+  // of 'greaterEqual' below, which readily clears the ZF. This makes C2 code a little simpler and
+  // avoids one branch.
+  cmpl(Address(thread, JavaThread::lock_stack_top_offset()), LockStack::end_offset() - 1);
+  jcc(Assembler::greater, slow);
 
   // Now we attempt to take the fast-lock.
-  // Clear lowest two header bits (locked state).
-  andptr(hdr, ~(int32_t )markWord::lock_mask_in_place);
+  // Clear lock_mask bits (locked state).
+  andptr(hdr, ~(int32_t)markWord::lock_mask_in_place);
   movptr(tmp, hdr);
-  // Set lowest bit (unlocked state).
+  // Set unlocked_value bit.
   orptr(hdr, markWord::unlocked_value);
   lock();
   cmpxchgptr(tmp, Address(obj, oopDesc::mark_offset_in_bytes()));
   jcc(Assembler::notEqual, slow);
 
   // If successful, push object to lock-stack.
-  movptr(tmp, Address(thread, JavaThread::lock_stack_current_offset()));
-  movptr(Address(tmp, 0), obj);
-  addptr(tmp, oopSize);
-  movptr(Address(thread, JavaThread::lock_stack_current_offset()), tmp);
+  movl(tmp, Address(thread, JavaThread::lock_stack_top_offset()));
+  movptr(Address(thread, tmp), obj);
+  incrementl(tmp, oopSize);
+  movl(Address(thread, JavaThread::lock_stack_top_offset()), tmp);
 }
 
+// Implements fast-unlocking.
+// Branches to slow upon failure, with ZF cleared.
+// Falls through upon success, with unspecified ZF.
+//
+// obj: the object to be unlocked
+// hdr: the (pre-loaded) header of the object, must be rax
+// tmp: a temporary register
 void MacroAssembler::fast_unlock_impl(Register obj, Register hdr, Register tmp, Label& slow) {
   assert(hdr == rax, "header must be in rax for cmpxchg");
   assert_different_registers(obj, hdr, tmp);
 
-  // Mark-word must be 00 now, try to swing it back to 01 (unlocked)
+  // Mark-word must be lock_mask now, try to swing it back to unlocked_value.
   movptr(tmp, hdr); // The expected old value
   orptr(tmp, markWord::unlocked_value);
   lock();
@@ -8838,7 +8829,11 @@ void MacroAssembler::fast_unlock_impl(Register obj, Register hdr, Register tmp, 
   const Register thread = r15_thread;
 #else
   const Register thread = rax;
-  get_thread(rax);
+  get_thread(thread);
 #endif
-  subptr(Address(thread, JavaThread::lock_stack_current_offset()), oopSize);
+  subl(Address(thread, JavaThread::lock_stack_top_offset()), oopSize);
+#ifdef ASSERT
+  movl(tmp, Address(thread, JavaThread::lock_stack_top_offset()));
+  movptr(Address(thread, tmp), 0);
+#endif
 }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1734,7 +1734,7 @@ public:
 
  public:
   // C2 compiled method's prolog code.
-  void verified_entry(int framesize, int stack_bang_size, bool fp_mode_24b, bool is_stub, int max_monitors);
+  void verified_entry(int framesize, int stack_bang_size, bool fp_mode_24b, bool is_stub);
 
   // clear memory of size 'cnt' qwords, starting at 'base';
   // if 'is_large' is set, do not try to produce short loop
@@ -1922,7 +1922,7 @@ public:
 
   void vallones(XMMRegister dst, int vector_len);
 
-  void fast_lock_impl(Register obj, Register hdr, Register thread, Register tmp, Label& slow, bool rt_check_stack = true);
+  void fast_lock_impl(Register obj, Register hdr, Register thread, Register tmp, Label& slow);
   void fast_unlock_impl(Register obj, Register hdr, Register tmp, Label& slow);
 };
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -2072,11 +2072,9 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // Load the oop from the handle
     __ movptr(obj_reg, Address(oop_handle_reg, 0));
 
-    if (UseFastLocking) {
-      // Load object header
-      __ movptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
-      __ fast_lock_impl(obj_reg, swap_reg, r15_thread, rscratch1, slow_path_lock);
-    } else {
+    if (LockingMode == LM_MONITOR) {
+      __ jmp(slow_path_lock);
+    } else if (LockingMode == LM_LEGACY) {
       if (UseBiasedLocking) {
         __ biased_locking_enter(lock_reg, obj_reg, swap_reg, rscratch1, rscratch2, false, lock_done, &slow_path_lock);
       }
@@ -2112,6 +2110,11 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       // Save the test result, for recursive case, the result is zero
       __ movptr(Address(lock_reg, mark_word_offset), swap_reg);
       __ jcc(Assembler::notEqual, slow_path_lock);
+    } else {
+      assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+      // Load object header
+      __ movptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+      __ fast_lock_impl(obj_reg, swap_reg, r15_thread, rscratch1, slow_path_lock);
     }
 
     // Slow path will re-enter here
@@ -2237,7 +2240,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       __ biased_locking_exit(obj_reg, old_hdr, done);
     }
 
-    if (!UseFastLocking) {
+    if (LockingMode == LM_LEGACY) {
       // Simple recursive lock?
 
       __ cmpptr(Address(rsp, lock_slot_offset * VMRegImpl::stack_slot_size), (int32_t)NULL_WORD);
@@ -2249,11 +2252,9 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       save_native_result(masm, ret_type, stack_slots);
     }
 
-    if (UseFastLocking) {
-      __ movptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
-      __ andptr(swap_reg, ~(int32_t)markWord::lock_mask_in_place);
-      __ fast_unlock_impl(obj_reg, swap_reg, lock_reg, slow_path_unlock);
-    } else {
+    if (LockingMode == LM_MONITOR) {
+      __ jmp(slow_path_unlock);
+    } else if (LockingMode == LM_LEGACY) {
       // get address of the stack lock
       __ lea(rax, Address(rsp, lock_slot_offset * VMRegImpl::stack_slot_size));
       //  get old displaced header
@@ -2263,6 +2264,11 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       __ lock();
       __ cmpxchgptr(old_hdr, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
       __ jcc(Assembler::notEqual, slow_path_unlock);
+    } else {
+      assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+      __ movptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+      __ andptr(swap_reg, ~(int32_t)markWord::lock_mask_in_place);
+      __ fast_unlock_impl(obj_reg, swap_reg, lock_reg, slow_path_unlock);
     }
 
     // slow path re-enters here

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -6801,58 +6801,6 @@ address generate_avx_ghash_processBlocks() {
     return start;
   }
 
-  // Call runtime to ensure lock-stack size.
-  // Arguments:
-  // - c_rarg0: the required _limit pointer
-  address generate_check_lock_stack() {
-    __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, "StubRoutines", "check_lock_stack");
-    address start = __ pc();
-
-    BLOCK_COMMENT("Entry:");
-    __ enter(); // save rbp
-
-    __ pusha();
-
-    // The method may have floats as arguments, and we must spill them before calling
-    // the VM runtime.
-    __ push_FPU_state();
-    /*
-    assert(Argument::n_float_register_parameters_j == 8, "Assumption");
-    const int xmm_size = wordSize * 2;
-    const int xmm_spill_size = xmm_size * Argument::n_float_register_parameters_j;
-    __ subptr(rsp, xmm_spill_size);
-    __ movdqu(Address(rsp, xmm_size * 7), xmm7);
-    __ movdqu(Address(rsp, xmm_size * 6), xmm6);
-    __ movdqu(Address(rsp, xmm_size * 5), xmm5);
-    __ movdqu(Address(rsp, xmm_size * 4), xmm4);
-    __ movdqu(Address(rsp, xmm_size * 3), xmm3);
-    __ movdqu(Address(rsp, xmm_size * 2), xmm2);
-    __ movdqu(Address(rsp, xmm_size * 1), xmm1);
-    __ movdqu(Address(rsp, xmm_size * 0), xmm0);
-    */
-    __ call_VM_leaf(CAST_FROM_FN_PTR(address, static_cast<void (*)(oop*)>(LockStack::ensure_lock_stack_size)), rax);
-    /*
-    __ movdqu(xmm0, Address(rsp, xmm_size * 0));
-    __ movdqu(xmm1, Address(rsp, xmm_size * 1));
-    __ movdqu(xmm2, Address(rsp, xmm_size * 2));
-    __ movdqu(xmm3, Address(rsp, xmm_size * 3));
-    __ movdqu(xmm4, Address(rsp, xmm_size * 4));
-    __ movdqu(xmm5, Address(rsp, xmm_size * 5));
-    __ movdqu(xmm6, Address(rsp, xmm_size * 6));
-    __ movdqu(xmm7, Address(rsp, xmm_size * 7));
-    __ addptr(rsp, xmm_spill_size);
-    */
-    __ pop_FPU_state();
-    __ popa();
-
-    __ leave();
-
-    __ ret(0);
-
-    return start;
-  }
-
    /**
    *  Arguments:
    *
@@ -7772,9 +7720,6 @@ address generate_avx_ghash_processBlocks() {
     BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
     if (bs_nm != NULL) {
       StubRoutines::x86::_method_entry_barrier = generate_method_entry_barrier();
-    }
-    if (UseFastLocking) {
-      StubRoutines::x86::_check_lock_stack = generate_check_lock_stack();
     }
 #ifdef COMPILER2
     if (UseMultiplyToLenIntrinsic) {

--- a/src/hotspot/cpu/x86/stubRoutines_x86.cpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.cpp
@@ -82,7 +82,6 @@ address StubRoutines::x86::_join_2_3_base64 = NULL;
 address StubRoutines::x86::_decoding_table_base64 = NULL;
 #endif
 address StubRoutines::x86::_pshuffle_byte_flip_mask_addr = NULL;
-address StubRoutines::x86::_check_lock_stack = NULL;
 
 //tables common for sin and cos
 address StubRoutines::x86::_ONEHALF_adr = NULL;

--- a/src/hotspot/cpu/x86/stubRoutines_x86.hpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.hpp
@@ -131,8 +131,6 @@ class x86 {
 
   static address _method_entry_barrier;
 
-  static address _check_lock_stack;
-
   // masks and table for CRC32
   static uint64_t _crc_by128_masks[];
   static juint    _crc_table[];
@@ -267,8 +265,6 @@ class x86 {
   static address shuffle_byte_flip_mask_addr() { return _shuffle_byte_flip_mask_addr; }
   static address k256_addr()      { return _k256_adr; }
   static address method_entry_barrier() { return _method_entry_barrier; }
-
-  static address check_lock_stack() { return _check_lock_stack; }
 
   static address vector_short_to_byte_mask() {
     return _vector_short_to_byte_mask;

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -627,8 +627,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   int framesize = C->output()->frame_size_in_bytes();
   int bangsize = C->output()->bang_size_in_bytes();
 
-  int max_monitors = C->method() != NULL ? C->max_monitors() : 0;
-  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, C->in_24_bit_fp_mode(), C->stub_function() != NULL, max_monitors);
+  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, C->in_24_bit_fp_mode(), C->stub_function() != NULL);
 
   C->output()->set_frame_complete(cbuf.insts_size());
 

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -900,8 +900,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     __ bind(L_skip_barrier);
   }
 
-  int max_monitors = C->method() != NULL ? C->max_monitors() : 0;
-  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, false, C->stub_function() != NULL, max_monitors);
+  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, false, C->stub_function() != NULL);
 
   C->output()->set_frame_complete(cbuf.insts_size());
 

--- a/src/hotspot/cpu/zero/vm_version_zero.cpp
+++ b/src/hotspot/cpu/zero/vm_version_zero.cpp
@@ -115,6 +115,11 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseVectorizedMismatchIntrinsic, false);
   }
 
+  if ((LockingMode != LM_LEGACY) && (LockingMode != LM_MONITOR)) {
+    warning("Unsupported locking mode for this CPU.");
+    FLAG_SET_DEFAULT(LockingMode, LM_LEGACY);
+  }
+
   // Not implemented
   UNSUPPORTED_OPTION(CriticalJNINatives);
   UNSUPPORTED_OPTION(UseCompiler);

--- a/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/zeroInterpreter_zero.cpp
@@ -333,7 +333,7 @@ int ZeroInterpreter::native_entry(Method* method, intptr_t UNUSED, TRAPS) {
     oop lockee = monitor->obj();
     markWord disp = lockee->mark().set_unlocked();
     monitor->lock()->set_displaced_header(disp);
-    bool call_vm = UseHeavyMonitors;
+    bool call_vm = (LockingMode == LM_MONITOR);
     if (call_vm || lockee->cas_set_mark(markWord::from_pointer(monitor), disp) != disp) {
       // Is it simple recursive case?
       if (!call_vm && thread->is_lock_owned((address) disp.clear_lock_bits().to_pointer())) {

--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -382,10 +382,6 @@ int Compilation::compile_java_method() {
     BAILOUT_("mdo allocation failed", no_frame_size);
   }
 
-  if (method()->is_synchronized()) {
-    push_monitor();
-  }
-
   {
     PhaseTraceTime timeit(_t_buildIR);
     build_hir();
@@ -562,7 +558,6 @@ Compilation::Compilation(AbstractCompiler* compiler, ciEnv* env, ciMethod* metho
 , _would_profile(false)
 , _has_method_handle_invokes(false)
 , _has_reserved_stack_access(method->has_reserved_stack_access())
-, _max_monitors(0)
 , _install_code(install_code)
 , _bailout_msg(NULL)
 , _exception_info_list(NULL)

--- a/src/hotspot/share/c1/c1_Compilation.hpp
+++ b/src/hotspot/share/c1/c1_Compilation.hpp
@@ -82,7 +82,6 @@ class Compilation: public StackObj {
   bool               _would_profile;
   bool               _has_method_handle_invokes;  // True if this method has MethodHandle invokes.
   bool               _has_reserved_stack_access;
-  int                _max_monitors; // Max number of active monitors, for fast-locking
   bool               _install_code;
   const char*        _bailout_msg;
   ExceptionInfoList* _exception_info_list;
@@ -138,7 +137,6 @@ class Compilation: public StackObj {
   bool has_exception_handlers() const            { return _has_exception_handlers; }
   bool has_fpu_code() const                      { return _has_fpu_code; }
   bool has_unsafe_access() const                 { return _has_unsafe_access; }
-  int max_monitors() const                       { return _max_monitors; }
   int max_vector_size() const                    { return 0; }
   ciMethod* method() const                       { return _method; }
   int osr_bci() const                            { return _osr_bci; }
@@ -168,8 +166,6 @@ class Compilation: public StackObj {
   void set_has_unsafe_access(bool f)             { _has_unsafe_access = f; }
   void set_would_profile(bool f)                 { _would_profile = f; }
   void set_has_access_indexed(bool f)            { _has_access_indexed = f; }
-  void push_monitor()                            { _max_monitors++; }
-
   // Add a set of exception handlers covering the given PC offset
   void add_exception_handlers_for_pco(int pco, XHandlers* exception_handlers);
   // Statistics gathering

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2236,7 +2236,6 @@ void GraphBuilder::instance_of(int klass_index) {
 void GraphBuilder::monitorenter(Value x, int bci) {
   // save state before locking in case of deoptimization after a NullPointerException
   ValueStack* state_before = copy_state_for_exception_with_bci(bci);
-  compilation()->push_monitor();
   append_with_bci(new MonitorEnter(x, state()->lock(x), state_before), bci);
   kill_all();
 }

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -758,7 +758,7 @@ void LIR_Assembler::emit_op2(LIR_Op2* op) {
 
 
 void LIR_Assembler::build_frame() {
-  _masm->build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes(), compilation()->max_monitors());
+  _masm->build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes());
 }
 
 

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -636,7 +636,7 @@ void LIRGenerator::monitor_exit(LIR_Opr object, LIR_Opr lock, LIR_Opr new_hdr, L
   // setup registers
   LIR_Opr hdr = lock;
   lock = new_hdr;
-  CodeStub* slow_path = new MonitorExitStub(lock, !UseHeavyMonitors, monitor_no);
+  CodeStub* slow_path = new MonitorExitStub(lock, LockingMode != LM_MONITOR, monitor_no);
   __ load_stack_address_monitor(monitor_no, lock);
   __ unlock_object(hdr, object, lock, scratch, slow_path);
 }

--- a/src/hotspot/share/c1/c1_MacroAssembler.hpp
+++ b/src/hotspot/share/c1/c1_MacroAssembler.hpp
@@ -39,7 +39,7 @@ class C1_MacroAssembler: public MacroAssembler {
   void explicit_null_check(Register base);
 
   void inline_cache_check(Register receiver, Register iCache);
-  void build_frame(int frame_size_in_bytes, int bang_size_in_bytes, int max_monitors);
+  void build_frame(int frame_size_in_bytes, int bang_size_in_bytes);
   void remove_frame(int frame_size_in_bytes);
 
   void verified_entry(bool breakAtEntry);

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -703,7 +703,7 @@ JRT_BLOCK_ENTRY(void, Runtime1::monitorenter(JavaThread* current, oopDesc* obj, 
     lock->set_obj(obj);
   }
   assert(LockingMode == LM_LIGHTWEIGHT || obj == lock->obj(), "must match");
-  SharedRuntime::monitor_enter_helper(obj, LockingMode == LM_LIGHTWEIGHT ? nullptr : lock->lock(), current);
+  SharedRuntime::monitor_enter_helper(obj, LockingMode == LM_LIGHTWEIGHT ? NULL : lock->lock(), current);
 JRT_END
 
 

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -699,11 +699,11 @@ JRT_END
 
 JRT_BLOCK_ENTRY(void, Runtime1::monitorenter(JavaThread* current, oopDesc* obj, BasicObjectLock* lock))
   NOT_PRODUCT(_monitorenter_slowcase_cnt++;)
-  if (UseHeavyMonitors) {
+  if (LockingMode == LM_MONITOR) {
     lock->set_obj(obj);
   }
-  assert(UseFastLocking || obj == lock->obj(), "must match");
-  SharedRuntime::monitor_enter_helper(obj, UseFastLocking ? NULL : lock->lock(), current);
+  assert(LockingMode == LM_LIGHTWEIGHT || obj == lock->obj(), "must match");
+  SharedRuntime::monitor_enter_helper(obj, LockingMode == LM_LIGHTWEIGHT ? nullptr : lock->lock(), current);
 JRT_END
 
 

--- a/src/hotspot/share/c1/c1_globals.hpp
+++ b/src/hotspot/share/c1/c1_globals.hpp
@@ -248,6 +248,9 @@
   develop(bool, UseFastNewObjectArray, true,                                \
           "Use fast inlined object array allocation")                       \
                                                                             \
+  develop(bool, UseFastLocking, true,                                       \
+          "Use fast inlined locking code")                                  \
+                                                                            \
   develop(bool, UseSlowPath, false,                                         \
           "For debugging: test slow cases by always using them")            \
                                                                             \

--- a/src/hotspot/share/gc/shenandoah/shenandoahObjectUtils.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahObjectUtils.inline.hpp
@@ -44,7 +44,6 @@ markWord ShenandoahObjectUtils::stable_mark(oop obj) {
   markWord mark = obj->mark_acquire();
 
   assert(!mark.is_being_inflated(), "can not be inflating");
-  assert(!mark.has_locker(), "can not be stack-locked");
 
   // The mark can be in one of the following states:
   // *  Marked       - object is forwarded, try again on forwardee

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -755,7 +755,7 @@ JRT_ENTRY_NO_ASYNC(void, InterpreterRuntime::monitorenter_obj(JavaThread* curren
   Handle h_obj(current, cast_to_oop(obj));
   assert(Universe::heap()->is_in_or_null(h_obj()),
          "must be null or an object");
-  ObjectSynchronizer::enter(h_obj, nullptr, current);
+  ObjectSynchronizer::enter(h_obj, NULL, current);
   return;
 JRT_END
 

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -724,15 +724,7 @@ void InterpreterRuntime::resolve_get_put(JavaThread* current, Bytecodes::Code by
 
 //%note monitor_1
 JRT_ENTRY_NO_ASYNC(void, InterpreterRuntime::monitorenter(JavaThread* current, BasicObjectLock* elem))
-  if (!UseHeavyMonitors && UseFastLocking) {
-    // This is a hack to get around the limitation of registers in x86_32. We really
-    // send an oopDesc* instead of a BasicObjectLock*.
-    Handle h_obj(current, oop((reinterpret_cast<oopDesc*>(elem))));
-    assert(Universe::heap()->is_in_or_null(h_obj()),
-           "must be NULL or an object");
-    ObjectSynchronizer::enter(h_obj, NULL, current);
-    return;
-  }
+  assert(LockingMode != LM_LIGHTWEIGHT, "Should call monitorenter_obj() when using the new lightweight locking");
 #ifdef ASSERT
   current->last_frame().interpreter_frame_verify_monitor(elem);
 #endif
@@ -750,6 +742,22 @@ JRT_ENTRY_NO_ASYNC(void, InterpreterRuntime::monitorenter(JavaThread* current, B
 #endif
 JRT_END
 
+// NOTE: We provide a separate implementation for the new lightweight locking to workaround a limitation
+// of registers in x86_32. This entry point accepts an oop instead of a BasicObjectLock*.
+// The problem is that we would need to preserve the register that holds the BasicObjectLock,
+// but we are using that register to hold the thread. We don't have enough registers to
+// also keep the BasicObjectLock, but we don't really need it anyway, we only need
+// the object. See also InterpreterMacroAssembler::lock_object().
+// As soon as legacy stack-locking goes away we could remove the other monitorenter() entry
+// point, and only use oop-accepting entries (same for monitorexit() below).
+JRT_ENTRY_NO_ASYNC(void, InterpreterRuntime::monitorenter_obj(JavaThread* current, oopDesc* obj))
+  assert(LockingMode == LM_LIGHTWEIGHT, "Should call monitorenter() when not using the new lightweight locking");
+  Handle h_obj(current, cast_to_oop(obj));
+  assert(Universe::heap()->is_in_or_null(h_obj()),
+         "must be null or an object");
+  ObjectSynchronizer::enter(h_obj, nullptr, current);
+  return;
+JRT_END
 
 JRT_LEAF(void, InterpreterRuntime::monitorexit(BasicObjectLock* elem))
   oop obj = elem->obj();

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -106,6 +106,7 @@ class InterpreterRuntime: AllStatic {
  public:
   // Synchronization
   static void    monitorenter(JavaThread* current, BasicObjectLock* elem);
+  static void    monitorenter_obj(JavaThread* current, oopDesc* obj);
   static void    monitorexit (BasicObjectLock* elem);
 
   static void    throw_illegal_monitor_state_exception(JavaThread* current);

--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -627,7 +627,7 @@ void BytecodeInterpreter::run(interpreterState istate) {
         // Traditional lightweight locking.
         markWord displaced = rcvr->mark().set_unlocked();
         mon->lock()->set_displaced_header(displaced);
-        bool call_vm = UseHeavyMonitors;
+        bool call_vm = (LockingMode == LM_MONITOR);
         if (call_vm || rcvr->cas_set_mark(markWord::from_pointer(mon), displaced) != displaced) {
           // Is it simple recursive case?
           if (!call_vm && THREAD->is_lock_owned((address) displaced.clear_lock_bits().to_pointer())) {
@@ -723,7 +723,7 @@ void BytecodeInterpreter::run(interpreterState istate) {
       // traditional lightweight locking
       markWord displaced = lockee->mark().set_unlocked();
       entry->lock()->set_displaced_header(displaced);
-      bool call_vm = UseHeavyMonitors;
+      bool call_vm = (LockingMode == LM_MONITOR);
       if (call_vm || lockee->cas_set_mark(markWord::from_pointer(entry), displaced) != displaced) {
         // Is it simple recursive case?
         if (!call_vm && THREAD->is_lock_owned((address) displaced.clear_lock_bits().to_pointer())) {
@@ -1633,7 +1633,7 @@ run:
           // traditional lightweight locking
           markWord displaced = lockee->mark().set_unlocked();
           entry->lock()->set_displaced_header(displaced);
-          bool call_vm = UseHeavyMonitors;
+          bool call_vm = (LockingMode == LM_MONITOR);
           if (call_vm || lockee->cas_set_mark(markWord::from_pointer(entry), displaced) != displaced) {
             // Is it simple recursive case?
             if (!call_vm && THREAD->is_lock_owned((address) displaced.clear_lock_bits().to_pointer())) {
@@ -1665,7 +1665,7 @@ run:
             assert(!UseBiasedLocking, "Not implemented");
 
             // If it isn't recursive we either must swap old header or call the runtime
-            bool call_vm = UseHeavyMonitors;
+            bool call_vm = (LockingMode == LM_MONITOR);
             if (header.to_pointer() != NULL || call_vm) {
               markWord old_header = markWord::encode(lock);
               if (call_vm || lockee->cas_set_mark(header, old_header) != old_header) {
@@ -3148,7 +3148,7 @@ run:
               illegal_state_oop = Handle(THREAD, THREAD->pending_exception());
               THREAD->clear_pending_exception();
             }
-          } else if (UseHeavyMonitors) {
+          } else if (LockingMode == LM_MONITOR) {
             InterpreterRuntime::monitorexit(base);
             if (THREAD->has_pending_exception()) {
               if (!suppress_error) illegal_state_oop = Handle(THREAD, THREAD->pending_exception());

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -652,7 +652,10 @@ protected:
   // Note: the prototype header is always set up to be at least the
   // prototype markWord. If biased locking is enabled it may further be
   // biasable and have an epoch.
-  markWord prototype_header() const      { return _prototype_header; }
+  markWord prototype_header() const      {
+    assert(UseCompactObjectHeaders, "only use with compact object headers");
+    return _prototype_header;
+  }
 
   // NOTE: once instances of this klass are floating around in the
   // system, this header must only be updated at a safepoint.

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -652,10 +652,7 @@ protected:
   // Note: the prototype header is always set up to be at least the
   // prototype markWord. If biased locking is enabled it may further be
   // biasable and have an epoch.
-  markWord prototype_header() const      {
-    assert(UseCompactObjectHeaders, "only use with compact object headers");
-    return _prototype_header;
-  }
+  markWord prototype_header() const      { return _prototype_header; }
 
   // NOTE: once instances of this klass are floating around in the
   // system, this header must only be updated at a safepoint.

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -84,9 +84,9 @@
 //
 //    [ptr             | 00]  locked             ptr points to real header on stack
 //    [header      | 0 | 01]  unlocked           regular object header
-//    [ptr             | 10]  monitor            inflated lock (header is wapped out)
+//    [ptr             | 10]  monitor            inflated lock (header is swapped out)
 //    [ptr             | 11]  marked             used to mark an object
-//    [0 ............ 0| 00]  inflating          inflation in progress
+//    [0 ............ 0| 00]  inflating          inflation in progress (stack-locking in use)
 //
 //    We assume that stack/thread pointers have the lowest two bits cleared.
 //
@@ -262,6 +262,7 @@ class markWord {
   // check for and avoid overwriting a 0 value installed by some
   // other thread.  (They should spin or block instead.  The 0 value
   // is transient and *should* be short-lived).
+  // Fast-locking does not use INFLATING.
   static markWord INFLATING() { return zero(); }    // inflate-in-progress
 
   // Should this header be preserved during GC?

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -293,7 +293,8 @@ class markWord {
     return markWord(value() | unlocked_value);
   }
   bool has_locker() const {
-    return !UseFastLocking && ((value() & lock_mask_in_place) == locked_value);
+    assert(LockingMode == LM_LEGACY, "should only be called with legacy stack locking");
+    return (value() & lock_mask_in_place) == locked_value;
   }
   BasicLock* locker() const {
     assert(has_locker(), "check");
@@ -301,7 +302,8 @@ class markWord {
   }
 
   bool is_fast_locked() const {
-    return UseFastLocking && ((value() & lock_mask_in_place) == locked_value);
+    assert(LockingMode == LM_LIGHTWEIGHT, "should only be called with new lightweight locking");
+    return (value() & lock_mask_in_place) == locked_value;
   }
   markWord set_fast_locked() const {
     return markWord(value() & ~lock_mask_in_place);
@@ -311,14 +313,14 @@ class markWord {
     return ((value() & monitor_value) != 0);
   }
   ObjectMonitor* monitor() const {
-    assert(has_monitor(), "check");
+   assert(has_monitor(), "check");
     // Use xor instead of &~ to provide one extra tag-bit check.
     return (ObjectMonitor*) (value() ^ monitor_value);
   }
   bool has_displaced_mark_helper() const {
     intptr_t lockbits = value() & lock_mask_in_place;
-    return UseFastLocking ? lockbits == monitor_value   // monitor?
-                          : (lockbits & unlocked_value) == 0; // monitor | stack-locked?
+    return LockingMode == LM_LIGHTWEIGHT  ? lockbits == monitor_value   // monitor?
+                                          : (lockbits & unlocked_value) == 0; // monitor | stack-locked?
   }
   markWord displaced_mark_helper() const;
   void set_displaced_mark_helper(markWord m) const;

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -105,16 +105,16 @@ bool oopDesc::is_oop(oop obj, bool ignore_mark_word) {
   }
 
   // Header verification: the mark is typically non-zero. If we're
-  // at a safepoint, it must not be zero.
+  // at a safepoint, it must not be zero, except when using the new lightweight locking.
   // Outside of a safepoint, the header could be changing (for example,
   // another thread could be inflating a lock on this object).
-  if (ignore_mark_word || UseFastLocking) {
+  if (ignore_mark_word) {
     return true;
   }
   if (obj->mark().value() != 0) {
     return true;
   }
-  return !SafepointSynchronize::is_at_safepoint();
+  return LockingMode == LM_LIGHTWEIGHT || !SafepointSynchronize::is_at_safepoint();
 }
 
 // used only for asserts and guarantees

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -83,7 +83,7 @@ markWord oopDesc::cas_set_mark(markWord new_mark, markWord old_mark, atomic_memo
 }
 
 markWord oopDesc::resolve_mark() const {
-  assert(UseFastLocking, "Only safe with fast-locking");
+  assert(LockingMode != LM_LEGACY, "Not safe with legacy stack-locking");
   markWord hdr = mark();
   if (hdr.has_displaced_mark_helper()) {
     hdr = hdr.displaced_mark_helper();

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -993,7 +993,6 @@ void Compile::Init(int aliaslevel) {
   set_do_scheduling(OptoScheduling);
 
   set_do_vector_loop(false);
-  reset_max_monitors();
 
   if (AllowVectorizeOnDemand) {
     if (has_method() && (_directive->VectorizeOption || _directive->VectorizeDebugOption)) {

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -302,7 +302,6 @@ class Compile : public Phase {
   bool                  _has_irreducible_loop;  // Found irreducible loops
   // JSR 292
   bool                  _has_method_handle_invokes; // True if this method has MethodHandle invokes.
-  uint                  _max_monitors;          // Keep track of maximum number of active monitors in this compilation
   RTMState              _rtm_state;             // State of Restricted Transactional Memory usage
   int                   _loop_opts_cnt;         // loop opts round
   bool                  _clinit_barrier_on_entry; // True if clinit barrier is needed on nmethod entry
@@ -596,10 +595,6 @@ class Compile : public Phase {
   void          set_max_node_limit(uint n)       { _max_node_limit = n; }
   bool              clinit_barrier_on_entry()       { return _clinit_barrier_on_entry; }
   void          set_clinit_barrier_on_entry(bool z) { _clinit_barrier_on_entry = z; }
-
-  void          push_monitor() { _max_monitors++; }
-  void          reset_max_monitors() { _max_monitors = 0; }
-  uint          max_monitors() { return _max_monitors; }
 
   // check the CompilerOracle for special behaviours for this compile
   bool          method_has_option(enum CompileCommand option) {

--- a/src/hotspot/share/opto/locknode.cpp
+++ b/src/hotspot/share/opto/locknode.cpp
@@ -188,8 +188,6 @@ void FastLockNode::create_rtm_lock_counter(JVMState* state) {
 void Parse::do_monitor_enter() {
   kill_dead_locals();
 
-  C->push_monitor();
-
   // Null check; get casted pointer.
   Node* obj = null_check(peek());
   // Check for locking null object

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -423,11 +423,7 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
     C->set_has_reserved_stack_access(true);
   }
 
-  if (parse_method->is_synchronized()) {
-    C->push_monitor();
-  }
-
-   _tf = TypeFunc::make(method());
+  _tf = TypeFunc::make(method());
   _iter.reset_to_method(method());
   _flow = method()->get_flow_analysis();
   if (_flow->failing()) {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2003,6 +2003,22 @@ bool Arguments::check_vm_args_consistency() {
   }
 #endif
 
+#if !defined(X86) && !defined(AARCH64)
+  if (LockingMode == LM_LIGHTWEIGHT) {
+    FLAG_SET_CMDLINE(LockingMode, LM_LEGACY);
+    warning("New lightweight locking not supported on this platform");
+  }
+#endif
+
+  if (UseHeavyMonitors) {
+    if (FLAG_IS_CMDLINE(LockingMode) && LockingMode != LM_MONITOR) {
+      jio_fprintf(defaultStream::error_stream(),
+                  "Conflicting -XX:+UseHeavyMonitors and -XX:LockingMode=%d flags", LockingMode);
+      return false;
+    }
+    FLAG_SET_CMDLINE(LockingMode, LM_MONITOR);
+  }
+
   return status;
 }
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3159,14 +3159,11 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
     warning("Compact object headers require compressed class pointers. Disabling compact object headers.");
     FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
   }
-  if (UseCompactObjectHeaders) {
-    if (!UseFastLocking) {
-      // Lilliput requires fast-locking.
-      FLAG_SET_DEFAULT(UseFastLocking, true);
-    }
-    if (UseBiasedLocking) {
-      FLAG_SET_DEFAULT(UseBiasedLocking, false);
-    }
+  if (UseCompactObjectHeaders && LockingMode == LM_LEGACY) {
+    FLAG_SET_DEFAULT(LockingMode, LM_LIGHTWEIGHT);
+  }
+  if (UseCompactObjectHeaders && UseBiasedLocking) {
+    FLAG_SET_DEFAULT(UseBiasedLocking, false);
   }
   if (!UseCompactObjectHeaders) {
     FLAG_SET_DEFAULT(UseSharedSpaces, false);

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1472,7 +1472,7 @@ bool Deoptimization::relock_objects(JavaThread* thread, GrowableArray<MonitorInf
           markWord unbiased_prototype = markWord::prototype().set_age(mark.age());
           obj->set_mark(unbiased_prototype);
         } else if (exec_mode == Unpack_none) {
-          if (mark.has_locker() && fr.sp() > (intptr_t*)mark.locker()) {
+          if (LockingMode == LM_LEGACY && mark.has_locker() && fr.sp() > (intptr_t*)mark.locker()) {
             // With exec_mode == Unpack_none obj may be thread local and locked in
             // a callee frame. In this case the bias was revoked before in revoke_for_object_deoptimization().
             // Make the lock in the callee a recursive lock and restore the displaced header.

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2103,8 +2103,12 @@ const intx ObjectAlignmentInBytes = 8;
   product(size_t, HeapObjectStatsSamplingInterval, 500, DIAGNOSTIC,         \
              "Heap object statistics sampling interval (ms)")               \
                                                                             \
-  product(bool, UseFastLocking, false, EXPERIMENTAL,                        \
-                "Use fast-locking instead of stack-locking")                \
+  product(int, LockingMode, LM_LEGACY, EXPERIMENTAL,                        \
+          "Select locking mode: "                                           \
+          "0: monitors only (LM_MONITOR), "                                 \
+          "1: monitors & legacy stack-locking (LM_LEGACY, default), "       \
+          "2: monitors & new lightweight locking (LM_LIGHTWEIGHT)")         \
+          range(0, 2)                                                       \
                                                                             \
   develop(bool, TraceOptimizedUpcallStubs, false,                              \
                 "Trace optimized upcall stub generation")                      \

--- a/src/hotspot/share/runtime/lockStack.cpp
+++ b/src/hotspot/share/runtime/lockStack.cpp
@@ -41,7 +41,7 @@ LockStack::LockStack(JavaThread* jt) :
   _top(lock_stack_base_offset), _base() {
 #ifdef ASSERT
   for (int i = 0; i < CAPACITY; i++) {
-    _base[i] = nullptr;
+    _base[i] = NULL;
   }
 #endif
 }
@@ -66,13 +66,13 @@ void LockStack::verify(const char* msg) const {
   if (SafepointSynchronize::is_at_safepoint() || (Thread::current()->is_Java_thread() && is_owning_thread())) {
     int top = to_index(_top);
     for (int i = 0; i < top; i++) {
-      assert(_base[i] != nullptr, "no zapped before top");
+      assert(_base[i] != NULL, "no zapped before top");
       for (int j = i + 1; j < top; j++) {
         assert(_base[i] != _base[j], "entries must be unique: %s", msg);
       }
     }
     for (int i = top; i < CAPACITY; i++) {
-      assert(_base[i] == nullptr, "only zapped entries after top: i: %d, top: %d, entry: " PTR_FORMAT, i, top, p2i(_base[i]));
+      assert(_base[i] == NULL, "only zapped entries after top: i: %d, top: %d, entry: " PTR_FORMAT, i, top, p2i(_base[i]));
     }
   }
 }

--- a/src/hotspot/share/runtime/lockStack.cpp
+++ b/src/hotspot/share/runtime/lockStack.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,62 +25,55 @@
 
 #include "precompiled.hpp"
 #include "memory/allocation.hpp"
-#include "runtime/lockStack.hpp"
+#include "runtime/lockStack.inline.hpp"
 #include "runtime/safepoint.hpp"
+#include "runtime/stackWatermark.hpp"
+#include "runtime/stackWatermarkSet.inline.hpp"
 #include "runtime/thread.hpp"
 #include "utilities/copy.hpp"
 #include "utilities/ostream.hpp"
 
-LockStack::LockStack() :
-        _base(UseHeavyMonitors ? NULL : NEW_C_HEAP_ARRAY(oop, INITIAL_CAPACITY, mtSynchronizer)),
-        _limit(_base + INITIAL_CAPACITY),
-        _current(_base) {
+const int LockStack::lock_stack_offset =      in_bytes(JavaThread::lock_stack_offset());
+const int LockStack::lock_stack_top_offset =  in_bytes(JavaThread::lock_stack_top_offset());
+const int LockStack::lock_stack_base_offset = in_bytes(JavaThread::lock_stack_base_offset());
+
+LockStack::LockStack(JavaThread* jt) :
+  _top(lock_stack_base_offset), _base() {
+#ifdef ASSERT
+  for (int i = 0; i < CAPACITY; i++) {
+    _base[i] = nullptr;
+  }
+#endif
 }
 
-LockStack::~LockStack() {
-  if (!UseHeavyMonitors) {
-    FREE_C_HEAP_ARRAY(oop, _base);
-  }
+uint32_t LockStack::start_offset() {
+  int offset = lock_stack_base_offset;
+  assert(offset > 0, "must be positive offset");
+  return static_cast<uint32_t>(offset);
+}
+
+uint32_t LockStack::end_offset() {
+  int offset = lock_stack_base_offset + CAPACITY * oopSize;
+  assert(offset > 0, "must be positive offset");
+  return static_cast<uint32_t>(offset);
 }
 
 #ifndef PRODUCT
-void LockStack::validate(const char* msg) const {
-  assert(!UseHeavyMonitors, "never use lock-stack when fast-locking is disabled");
-  for (oop* loc1 = _base; loc1 < _current - 1; loc1++) {
-    for (oop* loc2 = loc1 + 1; loc2 < _current; loc2++) {
-      assert(*loc1 != *loc2, "entries must be unique: %s", msg);
+void LockStack::verify(const char* msg) const {
+  assert(LockingMode == LM_LIGHTWEIGHT, "never use lock-stack when light weight locking is disabled");
+  assert((_top <= end_offset()), "lockstack overflow: _top %d end_offset %d", _top, end_offset());
+  assert((_top >= start_offset()), "lockstack underflow: _top %d end_offset %d", _top, start_offset());
+  if (SafepointSynchronize::is_at_safepoint() || (Thread::current()->is_Java_thread() && is_owning_thread())) {
+    int top = to_index(_top);
+    for (int i = 0; i < top; i++) {
+      assert(_base[i] != nullptr, "no zapped before top");
+      for (int j = i + 1; j < top; j++) {
+        assert(_base[i] != _base[j], "entries must be unique: %s", msg);
+      }
+    }
+    for (int i = top; i < CAPACITY; i++) {
+      assert(_base[i] == nullptr, "only zapped entries after top: i: %d, top: %d, entry: " PTR_FORMAT, i, top, p2i(_base[i]));
     }
   }
 }
 #endif
-
-void LockStack::grow(size_t min_capacity) {
-  // Grow stack.
-  assert(_limit > _base, "invariant");
-  size_t capacity = _limit - _base;
-  size_t index = _current - _base;
-  size_t new_capacity = MAX2(min_capacity, capacity * 2);
-  oop* new_stack = NEW_C_HEAP_ARRAY(oop, new_capacity, mtSynchronizer);
-  for (size_t i = 0; i < index; i++) {
-    *(new_stack + i) = *(_base + i);
-  }
-  FREE_C_HEAP_ARRAY(oop, _base);
-  _base = new_stack;
-  _limit = _base + new_capacity;
-  _current = _base + index;
-  assert(_current < _limit, "must fit after growing");
-  assert((_limit - _base) >= (ptrdiff_t) min_capacity, "must grow enough");
-}
-
-void LockStack::grow() {
-  grow((_limit - _base) + 1);
-}
-
-void LockStack::grow(oop* required_limit) {
-  grow(required_limit - _base);
-}
-
-void LockStack::ensure_lock_stack_size(oop* _required_limit) {
-  JavaThread* jt = JavaThread::current();
-  jt->lock_stack().grow(_required_limit);
-}

--- a/src/hotspot/share/runtime/lockStack.inline.hpp
+++ b/src/hotspot/share/runtime/lockStack.inline.hpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,67 +28,106 @@
 
 #include "memory/iterator.hpp"
 #include "runtime/lockStack.hpp"
+#include "runtime/safepoint.hpp"
+#include "runtime/stackWatermark.hpp"
+#include "runtime/stackWatermarkSet.inline.hpp"
+#include "runtime/thread.hpp"
+
+inline int LockStack::to_index(uint32_t offset) {
+  return (offset - lock_stack_base_offset) / oopSize;
+}
+
+JavaThread* LockStack::get_thread() const {
+  char* addr = reinterpret_cast<char*>(const_cast<LockStack*>(this));
+  return reinterpret_cast<JavaThread*>(addr - lock_stack_offset);
+}
+
+inline bool LockStack::can_push() const {
+  return to_index(_top) < CAPACITY;
+}
+
+inline bool LockStack::is_owning_thread() const {
+  JavaThread* thread = JavaThread::current();
+  bool is_owning = &thread->lock_stack() == this;
+  assert(is_owning == (get_thread() == thread), "is_owning sanity");
+  return is_owning;
+}
 
 inline void LockStack::push(oop o) {
-  validate("pre-push");
+  verify("pre-push");
   assert(oopDesc::is_oop(o), "must be");
   assert(!contains(o), "entries must be unique");
-  if (_current >= _limit) {
-    grow();
-  }
-  *_current = o;
-  _current++;
-  validate("post-push");
+  assert(can_push(), "must have room");
+  assert(_base[to_index(_top)] == nullptr, "expect zapped entry");
+  _base[to_index(_top)] = o;
+  _top += oopSize;
+  verify("post-push");
 }
 
 inline oop LockStack::pop() {
-  validate("pre-pop");
-  oop* new_loc = _current - 1;
-  assert(new_loc < _current, "underflow, probably unbalanced push/pop");
-  _current = new_loc;
-  oop o = *_current;
-  assert(!contains(o), "entries must be unique");
-  validate("post-pop");
+  verify("pre-pop");
+  assert(to_index(_top) > 0, "underflow, probably unbalanced push/pop");
+  _top -= oopSize;
+  oop o = _base[to_index(_top)];
+#ifdef ASSERT
+  _base[to_index(_top)] = nullptr;
+#endif
+  assert(!contains(o), "entries must be unique: " PTR_FORMAT, p2i(o));
+  verify("post-pop");
   return o;
 }
 
 inline void LockStack::remove(oop o) {
-  validate("pre-remove");
-  assert(contains(o), "entry must be present");
-  for (oop* loc = _base; loc < _current; loc++) {
-    if (*loc == o) {
-      oop* last = _current - 1;
-      for (; loc < last; loc++) {
-        *loc = *(loc + 1);
+  verify("pre-remove");
+  assert(contains(o), "entry must be present: " PTR_FORMAT, p2i(o));
+  int end = to_index(_top);
+  for (int i = 0; i < end; i++) {
+    if (_base[i] == o) {
+      int last = end - 1;
+      for (; i < last; i++) {
+        _base[i] = _base[i + 1];
       }
-      _current--;
+      _top -= oopSize;
+#ifdef ASSERT
+      _base[to_index(_top)] = nullptr;
+#endif
       break;
     }
   }
   assert(!contains(o), "entries must be unique: " PTR_FORMAT, p2i(o));
-  validate("post-remove");
+  verify("post-remove");
 }
 
 inline bool LockStack::contains(oop o) const {
-  validate("pre-contains");
-  bool found = false;
-  size_t i = 0;
-  size_t found_i = 0;
-  for (oop* loc = _current - 1; loc >= _base; loc--) {
-    if (*loc == o) {
+  verify("pre-contains");
+  if (!SafepointSynchronize::is_at_safepoint() && !is_owning_thread()) {
+    // When a foreign thread inspects this thread's lock-stack, it may see
+    // bad references here when a concurrent collector has not gotten
+    // to processing the lock-stack, yet. Call StackWaterMark::start_processing()
+    // to ensure that all references are valid.
+    StackWatermark* watermark = StackWatermarkSet::get(get_thread(), StackWatermarkKind::gc);
+    if (watermark != nullptr) {
+      watermark->start_processing();
+    }
+  }
+  int end = to_index(_top);
+  for (int i = end - 1; i >= 0; i--) {
+    if (_base[i] == o) {
+      verify("post-contains");
       return true;
     }
   }
-  validate("post-contains");
+  verify("post-contains");
   return false;
 }
 
 inline void LockStack::oops_do(OopClosure* cl) {
-  validate("pre-oops-do");
-  for (oop* loc = _base; loc < _current; loc++) {
-    cl->do_oop(loc);
+  verify("pre-oops-do");
+  int end = to_index(_top);
+  for (int i = 0; i < end; i++) {
+    cl->do_oop(&_base[i]);
   }
-  validate("post-oops-do");
+  verify("post-oops-do");
 }
 
 #endif // SHARE_RUNTIME_LOCKSTACK_INLINE_HPP

--- a/src/hotspot/share/runtime/lockStack.inline.hpp
+++ b/src/hotspot/share/runtime/lockStack.inline.hpp
@@ -58,7 +58,7 @@ inline void LockStack::push(oop o) {
   assert(oopDesc::is_oop(o), "must be");
   assert(!contains(o), "entries must be unique");
   assert(can_push(), "must have room");
-  assert(_base[to_index(_top)] == nullptr, "expect zapped entry");
+  assert(_base[to_index(_top)] == NULL, "expect zapped entry");
   _base[to_index(_top)] = o;
   _top += oopSize;
   verify("post-push");
@@ -70,7 +70,7 @@ inline oop LockStack::pop() {
   _top -= oopSize;
   oop o = _base[to_index(_top)];
 #ifdef ASSERT
-  _base[to_index(_top)] = nullptr;
+  _base[to_index(_top)] = NULL;
 #endif
   assert(!contains(o), "entries must be unique: " PTR_FORMAT, p2i(o));
   verify("post-pop");
@@ -89,7 +89,7 @@ inline void LockStack::remove(oop o) {
       }
       _top -= oopSize;
 #ifdef ASSERT
-      _base[to_index(_top)] = nullptr;
+      _base[to_index(_top)] = NULL;
 #endif
       break;
     }
@@ -106,7 +106,7 @@ inline bool LockStack::contains(oop o) const {
     // to processing the lock-stack, yet. Call StackWaterMark::start_processing()
     // to ensure that all references are valid.
     StackWatermark* watermark = StackWatermarkSet::get(get_thread(), StackWatermarkKind::gc);
-    if (watermark != nullptr) {
+    if (watermark != NULL) {
       watermark->start_processing();
     }
   }

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -334,7 +334,7 @@ bool ObjectMonitor::enter(JavaThread* current) {
     return true;
   }
 
-  if (!UseFastLocking && current->is_lock_owned((address)cur)) {
+  if (LockingMode != LM_LIGHTWEIGHT && current->is_lock_owned((address)cur)) {
     assert(_recursions == 0, "internal state error");
     _recursions = 1;
     set_owner_from_BasicLock(cur, current);  // Convert from BasicLock* to Thread*.
@@ -1151,7 +1151,7 @@ void ObjectMonitor::UnlinkAfterAcquire(JavaThread* current, ObjectWaiter* curren
 void ObjectMonitor::exit(JavaThread* current, bool not_suspended) {
   void* cur = owner_raw();
   if (current != cur) {
-    if (!UseFastLocking && current->is_lock_owned((address)cur)) {
+    if (LockingMode != LM_LIGHTWEIGHT && current->is_lock_owned((address)cur)) {
       assert(_recursions == 0, "invariant");
       set_owner_from_BasicLock(cur, current);  // Convert from BasicLock* to Thread*.
       _recursions = 0;
@@ -1371,7 +1371,7 @@ intx ObjectMonitor::complete_exit(JavaThread* current) {
 
   void* cur = owner_raw();
   if (current != cur) {
-    if (!UseFastLocking && current->is_lock_owned((address)cur)) {
+    if (LockingMode != LM_LIGHTWEIGHT && current->is_lock_owned((address)cur)) {
       assert(_recursions == 0, "internal state error");
       set_owner_from_BasicLock(cur, current);  // Convert from BasicLock* to Thread*.
       _recursions = 0;
@@ -1420,11 +1420,11 @@ bool ObjectMonitor::reenter(intx recursions, JavaThread* current) {
 bool ObjectMonitor::check_owner(TRAPS) {
   JavaThread* current = THREAD;
   void* cur = owner_raw();
-  assert(cur != ANONYMOUS_OWNER, "no anon owner here");
+  assert(cur != anon_owner_ptr(), "no anon owner here");
   if (cur == current) {
     return true;
   }
-  if (!UseFastLocking && current->is_lock_owned((address)cur)) {
+  if (LockingMode != LM_LIGHTWEIGHT && current->is_lock_owned((address)cur)) {
     set_owner_from_BasicLock(cur, current);  // Convert from BasicLock* to Thread*.
     _recursions = 0;
     return true;

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -279,7 +279,7 @@ private:
   void*     try_set_owner_from(void* old_value, void* new_value);
 
   void set_owner_anonymous() {
-    set_owner_from(nullptr, anon_owner_ptr());
+    set_owner_from(NULL, anon_owner_ptr());
   }
 
   bool is_owner_anonymous() const {

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -148,13 +148,19 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   // Used by async deflation as a marker in the _owner field.
   // Note that the choice of the two markers is peculiar:
   // - They need to represent values that cannot be pointers. In particular,
-  //   we achieve this by using the lowest two bits
+  //   we achieve this by using the lowest two bits.
   // - ANONYMOUS_OWNER should be a small value, it is used in generated code
-  //   and small values encode much better
+  //   and small values encode much better.
   // - We test for anonymous owner by testing for the lowest bit, therefore
   //   DEFLATER_MARKER must *not* have that bit set.
   #define DEFLATER_MARKER reinterpret_cast<void*>(2)
-  #define ANONYMOUS_OWNER reinterpret_cast<void*>(1)
+public:
+  // NOTE: Typed as uintptr_t so that we can pick it up in SA, via vmStructs.
+  static const uintptr_t ANONYMOUS_OWNER = 1;
+
+private:
+  static void* anon_owner_ptr() { return reinterpret_cast<void*>(ANONYMOUS_OWNER); }
+
   void* volatile _owner;            // pointer to owning thread OR BasicLock
   volatile jlong _previous_owner_tid;  // thread id of the previous owner of the monitor
   // Separate _owner and _next_om on different cache lines since
@@ -252,7 +258,7 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   }
   const char* is_busy_to_string(stringStream* ss);
 
-  intptr_t  is_entered(JavaThread* current) const;
+  bool is_entered(JavaThread* current) const;
 
   bool      has_owner() const;
   void*     owner() const;  // Returns NULL if DEFLATER_MARKER is observed.
@@ -273,15 +279,15 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   void*     try_set_owner_from(void* old_value, void* new_value);
 
   void set_owner_anonymous() {
-    set_owner_from(NULL, ANONYMOUS_OWNER);
+    set_owner_from(nullptr, anon_owner_ptr());
   }
 
   bool is_owner_anonymous() const {
-    return owner_raw() == ANONYMOUS_OWNER;
+    return owner_raw() == anon_owner_ptr();
   }
 
   void set_owner_from_anonymous(Thread* owner) {
-    set_owner_from(ANONYMOUS_OWNER, owner);
+    set_owner_from(anon_owner_ptr(), owner);
   }
 
   // Simply get _next_om field.

--- a/src/hotspot/share/runtime/objectMonitor.inline.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.inline.hpp
@@ -33,20 +33,20 @@
 #include "runtime/lockStack.inline.hpp"
 #include "runtime/synchronizer.hpp"
 
-inline intptr_t ObjectMonitor::is_entered(JavaThread* current) const {
-  if (UseFastLocking) {
+inline bool ObjectMonitor::is_entered(JavaThread* current) const {
+  if (LockingMode == LM_LIGHTWEIGHT) {
     if (is_owner_anonymous()) {
-      return current->lock_stack().contains(object()) ? 1 : 0;
+      return current->lock_stack().contains(object());
     } else {
-      return current == owner_raw() ? 1 : 0;
+      return current == owner_raw();
     }
   } else {
     void* owner = owner_raw();
     if (current == owner || current->is_lock_owned((address)owner)) {
-      return 1;
+      return true;
     }
   }
-  return 0;
+  return false;
 }
 
 inline markWord ObjectMonitor::header() const {

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -703,7 +703,7 @@ void Thread::print_owned_locks_on(outputStream* st) const {
 // should be revisited, and they should be removed if possible.
 
 bool Thread::is_lock_owned(address adr) const {
-  assert(!UseFastLocking, "maybe not call that?");
+  assert(LockingMode != LM_LIGHTWEIGHT, "should not be called with new lightweight locking");
   return is_in_full_stack(adr);
 }
 
@@ -1094,8 +1094,8 @@ JavaThread::JavaThread() :
   _class_to_be_initialized(nullptr),
 
   _SleepEvent(ParkEvent::Allocate(this)),
-  _lock_stack()
-{
+
+  _lock_stack(this) {
   set_jni_functions(jni_functions());
 
 #if INCLUDE_JVMCI
@@ -1572,7 +1572,7 @@ JavaThread* JavaThread::active() {
 }
 
 bool JavaThread::is_lock_owned(address adr) const {
-  assert(!UseFastLocking, "should not be called with fast-locking");
+  assert(LockingMode != LM_LIGHTWEIGHT, "should not be called with new lightweight locking");
  if (Thread::is_lock_owned(adr)) return true;
 
   for (MonitorChunk* chunk = monitor_chunks(); chunk != NULL; chunk = chunk->next()) {
@@ -2024,7 +2024,7 @@ void JavaThread::oops_do_no_frames(OopClosure* f, CodeBlobClosure* cf) {
     jvmti_thread_state()->oops_do(f, cf);
   }
 
-  if (!UseHeavyMonitors && UseFastLocking) {
+  if (LockingMode == LM_LIGHTWEIGHT) {
     lock_stack().oops_do(f);
   }
 }
@@ -3717,7 +3717,7 @@ GrowableArray<JavaThread*>* Threads::get_pending_threads(ThreadsList * t_list,
 
 JavaThread *Threads::owning_thread_from_monitor_owner(ThreadsList * t_list,
                                                       address owner) {
-  assert(!UseFastLocking, "only with stack-locking");
+  assert(LockingMode != LM_LIGHTWEIGHT, "Not with new lightweight locking");
   // NULL owner means not locked so we can skip the search
   if (owner == NULL) return NULL;
 
@@ -3748,7 +3748,7 @@ JavaThread *Threads::owning_thread_from_monitor_owner(ThreadsList * t_list,
 }
 
 JavaThread* Threads::owning_thread_from_object(ThreadsList * t_list, oop obj) {
-  assert(UseFastLocking, "Only with fast-locking");
+  assert(LockingMode == LM_LIGHTWEIGHT, "Only with new lightweight locking");
   DO_JAVA_THREADS(t_list, q) {
     if (q->lock_stack().contains(obj)) {
       return q;
@@ -3758,31 +3758,17 @@ JavaThread* Threads::owning_thread_from_object(ThreadsList * t_list, oop obj) {
 }
 
 JavaThread* Threads::owning_thread_from_monitor(ThreadsList* t_list, ObjectMonitor* monitor) {
-  if (UseFastLocking) {
-    void* raw_owner = monitor->owner_raw();
-    if (raw_owner == ANONYMOUS_OWNER) {
+  if (LockingMode == LM_LIGHTWEIGHT) {
+    if (monitor->is_owner_anonymous()) {
       return owning_thread_from_object(t_list, monitor->object());
-    } else if (raw_owner == DEFLATER_MARKER) {
-      return NULL;
     } else {
-      Thread* owner = reinterpret_cast<Thread*>(raw_owner);
-#ifdef ASSERT
-      if (owner != NULL) {
-        bool found = false;
-        DO_JAVA_THREADS(t_list, q) {
-          if (q == owner) {
-            found = true;;
-            break;
-          }
-        }
-        assert(found, "owner is not a thread: " PTR_FORMAT, p2i(owner));
-      }
-#endif
+      Thread* owner = reinterpret_cast<Thread*>(monitor->owner());
       assert(owner == NULL || owner->is_Java_thread(), "only JavaThreads own monitors");
       return reinterpret_cast<JavaThread*>(owner);
     }
   } else {
-    return owning_thread_from_monitor_owner(t_list, (address)monitor->owner());
+    address owner = (address)monitor->owner();
+    return owning_thread_from_monitor_owner(t_list, owner);
   }
 }
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1618,9 +1618,12 @@ private:
 public:
   LockStack& lock_stack() { return _lock_stack; }
 
-  static ByteSize lock_stack_current_offset()    { return byte_offset_of(JavaThread, _lock_stack) + LockStack::current_offset(); }
-  static ByteSize lock_stack_limit_offset()    { return byte_offset_of(JavaThread, _lock_stack) + LockStack::limit_offset(); }
-
+  static ByteSize lock_stack_offset()      { return byte_offset_of(JavaThread, _lock_stack); }
+  // Those offsets are used in code generators to access the LockStack that is embedded in this
+  // JavaThread structure. Those accesses are relative to the current thread, which
+  // is typically in a dedicated register.
+  static ByteSize lock_stack_top_offset()  { return lock_stack_offset() + LockStack::top_offset(); }
+  static ByteSize lock_stack_base_offset() { return lock_stack_offset() + LockStack::base_offset(); }
 
   static OopStorage* thread_oop_storage();
 

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -735,8 +735,8 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   nonstatic_field(Thread,                      _tlab,                                         ThreadLocalAllocBuffer)                \
   nonstatic_field(Thread,                      _allocated_bytes,                              jlong)                                 \
   nonstatic_field(JavaThread,                  _lock_stack,                                   LockStack)                             \
-  nonstatic_field(LockStack,                   _current,                                      oop*)                                  \
-  nonstatic_field(LockStack,                   _base,                                         oop*)                                  \
+  nonstatic_field(LockStack,                   _top,                                          uint32_t)                              \
+  nonstatic_field(LockStack,                   _base[0],                                      oop)                                   \
   nonstatic_field(NamedThread,                 _name,                                         char*)                                 \
   nonstatic_field(NamedThread,                 _processed_thread,                             Thread*)                               \
   nonstatic_field(JavaThread,                  _threadObj,                                    OopHandle)                             \
@@ -2475,6 +2475,14 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   declare_constant(T_NARROWKLASS_size)                                    \
   declare_constant(T_VOID_size)                                           \
                                                                           \
+  /**********************************************/                        \
+  /* LockingMode enum (globalDefinitions.hpp) */                          \
+  /**********************************************/                        \
+                                                                          \
+  declare_constant(LM_MONITOR)                                            \
+  declare_constant(LM_LEGACY)                                             \
+  declare_constant(LM_LIGHTWEIGHT)                                        \
+                                                                          \
   /*********************/                                                 \
   /* Matcher (C2 only) */                                                 \
   /*********************/                                                 \
@@ -2674,8 +2682,10 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
                                                                           \
   /* InvocationCounter constants */                                       \
   declare_constant(InvocationCounter::count_increment)                    \
-  declare_constant(InvocationCounter::count_shift)
-
+  declare_constant(InvocationCounter::count_shift)                        \
+                                                                          \
+  /* ObjectMonitor constants */                                           \
+  declare_constant(ObjectMonitor::ANONYMOUS_OWNER)                        \
 
 //--------------------------------------------------------------------------------
 //

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -957,6 +957,15 @@ enum JavaThreadState {
   _thread_max_state         = 12  // maximum thread state+1 - used for statistics allocation
 };
 
+enum LockingMode {
+  // Use only heavy monitors for locking
+  LM_MONITOR     = 0,
+  // Legacy stack-locking, with monitors as 2nd tier
+  LM_LEGACY      = 1,
+  // New lightweight locking, with monitors as 2nd tier
+  LM_LIGHTWEIGHT = 2
+};
+
 //----------------------------------------------------------------------------------------------------
 // Special constants for debugging
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
@@ -44,7 +44,7 @@ public class JavaThread extends Thread {
   private static final boolean DEBUG = System.getProperty("sun.jvm.hotspot.runtime.JavaThread.DEBUG") != null;
 
   private static long          threadObjFieldOffset;
-  private static long          lockStackCurrentOffset;
+  private static long          lockStackTopOffset;
   private static long          lockStackBaseOffset;
   private static AddressField  anchorField;
   private static AddressField  lastJavaSPField;
@@ -100,8 +100,8 @@ public class JavaThread extends Thread {
     stackSizeField    = type.getCIntegerField("_stack_size");
     terminatedField   = type.getCIntegerField("_terminated");
 
-    lockStackCurrentOffset = type.getField("_lock_stack").getOffset() + typeLockStack.getField("_current").getOffset();
-    lockStackBaseOffset = type.getField("_lock_stack").getOffset() + typeLockStack.getField("_base").getOffset();
+    lockStackTopOffset = type.getField("_lock_stack").getOffset() + typeLockStack.getField("_top").getOffset();
+    lockStackBaseOffset = type.getField("_lock_stack").getOffset() + typeLockStack.getField("_base[0]").getOffset();
     oopPtrSize = VM.getVM().getAddressSize();
 
     UNINITIALIZED     = db.lookupIntConstant("_thread_uninitialized").intValue();
@@ -401,14 +401,18 @@ public class JavaThread extends Thread {
   }
 
   public boolean isLockOwned(OopHandle obj) {
-    Address current = addr.getAddressAt(lockStackCurrentOffset);
-    Address base = addr.getAddressAt(lockStackBaseOffset);
-    while (base.lessThan(current)) {
-      Address oop = base.getAddressAt(0);
+    long current = lockStackBaseOffset;
+    long end = addr.getJIntAt(lockStackTopOffset);
+    if (Assert.ASSERTS_ENABLED) {
+      Assert.that(current <= end, "current stack offset must be above base offset");
+    }
+
+    while (current < end) {
+      Address oop = addr.getAddressAt(current);
       if (oop.equals(obj)) {
         return true;
       }
-      base = base.addOffsetTo(oopPtrSize);
+      current += oopPtrSize;
     }
     return false;
   }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
@@ -77,6 +77,9 @@ public abstract class JavaVFrame extends VFrame {
     if (mark.hasMonitor() &&
         ( // we have marked ourself as pending on this monitor
           mark.monitor().equals(thread.getCurrentPendingMonitor()) ||
+          // Owned anonymously means that we are not the owner of
+          // the monitor and must be waiting for the owner to
+          // exit it.
           mark.monitor().isOwnedAnonymous() ||
           // we are not the owner of this monitor
           !mark.monitor().isEntered(thread)

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/LockingMode.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/LockingMode.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package sun.jvm.hotspot.runtime;
+
+import sun.jvm.hotspot.types.TypeDataBase;
+
+
+/** Encapsulates the LockingMode enum in globalDefinitions.hpp in
+    the VM. */
+
+public class LockingMode {
+  private static int monitor;
+  private static int legacy;
+  private static int lightweight;
+
+  static {
+    VM.registerVMInitializedObserver(
+        (o, d) -> initialize(VM.getVM().getTypeDataBase()));
+  }
+
+  private static synchronized void initialize(TypeDataBase db) {
+    monitor     = db.lookupIntConstant("LM_MONITOR").intValue();
+    legacy      = db.lookupIntConstant("LM_LEGACY").intValue();
+    lightweight = db.lookupIntConstant("LM_LIGHTWEIGHT").intValue();
+  }
+
+  public static int getMonitor() {
+    return monitor;
+  }
+
+  public static int getLegacy() {
+    return legacy;
+  }
+
+  public static int getLightweight() {
+    return lightweight;
+  }
+}

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ObjectMonitor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ObjectMonitor.java
@@ -55,6 +55,8 @@ public class ObjectMonitor extends VMObject {
     contentionsField  = type.getJIntField("_contentions");
     waitersField = type.getJIntField("_waiters");
     recursionsField = type.getCIntegerField("_recursions");
+
+    ANONYMOUS_OWNER = db.lookupLongConstant("ObjectMonitor::ANONYMOUS_OWNER").longValue();
   }
 
   public ObjectMonitor(Address addr) {
@@ -80,7 +82,7 @@ public class ObjectMonitor extends VMObject {
   }
 
   public boolean isOwnedAnonymous() {
-    return addr.getAddressAt(ownerFieldOffset).asLongValue() == 1;
+    return addr.getAddressAt(ownerFieldOffset).asLongValue() == ANONYMOUS_OWNER;
   }
 
   public Address owner() { return addr.getAddressAt(ownerFieldOffset); }
@@ -118,5 +120,7 @@ public class ObjectMonitor extends VMObject {
   private static JIntField     contentionsField;
   private static JIntField     waitersField;
   private static CIntegerField recursionsField;
+  private static long          ANONYMOUS_OWNER;
+
   // FIXME: expose platform-dependent stuff
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
@@ -208,7 +208,7 @@ public class Threads {
 
     // refer to Threads::owning_thread_from_monitor_owner
     public JavaThread owningThreadFromMonitor(Address o) {
-        assert(!VM.getVM().getCommandLineBooleanFlag("UseFastLocking"));
+        assert(VM.getVM().getCommandLineFlag("LockingMode").getInt() != LockingMode.getLightweight());
         if (o == null) return null;
         for (int i = 0; i < getNumberOfThreads(); i++) {
             JavaThread thread = getJavaThreadAt(i);
@@ -226,7 +226,7 @@ public class Threads {
     }
 
     public JavaThread owningThreadFromMonitor(ObjectMonitor monitor) {
-        if (VM.getVM().getCommandLineBooleanFlag("UseFastLocking")) {
+        if (VM.getVM().getCommandLineFlag("LockingMode").getInt() == LockingMode.getLightweight()) {
             if (monitor.isOwnedAnonymous()) {
                 OopHandle object = monitor.object();
                 for (int i = 0; i < getNumberOfThreads(); i++) {

--- a/test/hotspot/jtreg/runtime/logging/MonitorInflationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/MonitorInflationTest.java
@@ -37,7 +37,7 @@ import jdk.test.lib.process.ProcessTools;
 public class MonitorInflationTest {
     static void analyzeOutputOn(ProcessBuilder pb) throws Exception {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldContain("inflate(locked):");
+        output.shouldContain("inflate(has_locker):");
         output.shouldContain("type='MonitorInflationTest$Waiter'");
         output.shouldContain("I've been waiting.");
         output.shouldHaveExitValue(0);


### PR DESCRIPTION
This brings "8291555: Implement alternative fast-locking scheme" into lilliput/jdk17. Lots of small improvements, most importantly the fixed-size lock-stack, plus tons of testing and reviews that went into the upstream change that went into JDK21.

Testing:
 - [x] tier1 (x86, x86_64, aarch64)
 - [x] tier2 (x86, x86_64, aarch64)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308107](https://bugs.openjdk.org/browse/JDK-8308107): [Lilliput/JDK17] Cherry-pick: 8291555: Implement alternative fast-locking scheme


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/19.diff">https://git.openjdk.org/lilliput-jdk17u/pull/19.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/19#issuecomment-1551359492)