### PR TITLE
8308641: [Lilliput/JDK17] Remove wrong assert in klass.hpp

### DIFF
--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -652,10 +652,7 @@ protected:
   // Note: the prototype header is always set up to be at least the
   // prototype markWord. If biased locking is enabled it may further be
   // biasable and have an epoch.
-  markWord prototype_header() const      {
-    assert(UseCompactObjectHeaders, "only use with compact object headers");
-    return _prototype_header;
-  }
+  markWord prototype_header() const      { return _prototype_header; }
 
   // NOTE: once instances of this klass are floating around in the
   // system, this header must only be updated at a safepoint.


### PR DESCRIPTION
In klass.hpp, Klass::prototype_header() we have an assert(UseCompactObjectHeaders) which came from the similar upstream jdk21 change, but is wrong in jdk17, because the prototype_header() will also be used when biased locking is used. Biased locking is disabled by default, and the assert is harmless in release builds, but it makes a bunch of tests fail. Let's remove the assert and reduce upstream-jdk17u diff a little bit.

Testing:
 - [x] tier1 on x86, where some tests failed before

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308641](https://bugs.openjdk.org/browse/JDK-8308641): [Lilliput/JDK17] Remove wrong assert in klass.hpp


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/23.diff">https://git.openjdk.org/lilliput-jdk17u/pull/23.diff</a>

</details>
