### PR TITLE
8308647: [Lilliput/JDK17] Fix cross-builds

### DIFF
--- a/src/hotspot/share/oops/arrayOop.hpp
+++ b/src/hotspot/share/oops/arrayOop.hpp
@@ -128,6 +128,17 @@ class arrayOopDesc : public oopDesc {
     *length_addr_impl(mem) = length;
   }
 
+  // Should only be called with constants as argument
+  // (will not constant fold otherwise)
+  // Returns the header size in words aligned to the requirements of the
+  // array object type.
+  static int header_size(BasicType type) {
+    size_t typesize_in_bytes = header_size_in_bytes();
+    return (int)(element_type_should_be_aligned(type)
+      ? align_object_offset(typesize_in_bytes/HeapWordSize)
+      : typesize_in_bytes/HeapWordSize);
+  }
+
   // Return the maximum length of an array of BasicType.  The length can passed
   // to typeArrayOop::object_size(scale, length, header_size) without causing an
   // overflow. We also need to make sure that this will not overflow a size_t on


### PR DESCRIPTION
Some arches still require arrayOopDesc::header_size(BasicType) that we removed because it returns word-sized header-size, in favour of similar methods that return byte-sized header-size. Let's re-instate this old method to make cross-builds happy.

It also reduces the upstream diff. Let's see what the GHA of cross-builds say.

Testing:
 - [ ] GHA
 - [ ] build