### PR TITLE
8308651: [Lilliput/JDK17] Cherry-pick PPC parts of 8297036: Generalize C2 stub mechanism

### DIFF
--- a/src/hotspot/cpu/ppc/c2_CodeStubs_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c2_CodeStubs_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,19 +24,22 @@
  */
 
 #include "precompiled.hpp"
-#include "macroAssembler_ppc.inline.hpp"
-#include "opto/compile.hpp"
-#include "opto/node.hpp"
-#include "opto/output.hpp"
+#include "opto/c2_MacroAssembler.hpp"
+#include "opto/c2_CodeStubs.hpp"
 #include "runtime/sharedRuntime.hpp"
 
 #define __ masm.
-void C2SafepointPollStubTable::emit_stub_impl(MacroAssembler& masm, C2SafepointPollStub* entry) const {
+
+int C2SafepointPollStub::max_size() const {
+  return 56;
+}
+
+void C2SafepointPollStub::emit(C2_MacroAssembler& masm) {
   assert(SharedRuntime::polling_page_return_handler_blob() != NULL,
          "polling page return stub not created yet");
   address stub = SharedRuntime::polling_page_return_handler_blob()->entry_point();
 
-  __ bind(entry->_stub_label);
+  __ bind(entry());
   // Using pc relative address computation.
   {
     Label next_pc;
@@ -45,7 +48,7 @@ void C2SafepointPollStubTable::emit_stub_impl(MacroAssembler& masm, C2SafepointP
   }
   int current_offset = __ offset();
   // Code size should not depend on offset: see _stub_size computation in output.cpp
-  __ load_const32(R12, entry->_safepoint_offset - current_offset);
+  __ load_const32(R12, _safepoint_offset - current_offset);
   __ mflr(R0);
   __ add(R12, R12, R0);
   __ std(R12, in_bytes(JavaThread::saved_exception_pc_offset()), R16_thread);

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -982,6 +982,7 @@ source_hpp %{
 
 source %{
 
+#include "opto/c2_CodeStubs.hpp"
 #include "oops/klass.inline.hpp"
 
 void PhaseOutput::pd_perform_mach_node_analysis() {
@@ -1621,7 +1622,9 @@ void MachEpilogNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     Label dummy_label;
     Label* code_stub = &dummy_label;
     if (!UseSIGTRAP && !C->output()->in_scratch_emit_size()) {
-      code_stub = &C->output()->safepoint_poll_table()->add_safepoint(__ offset());
+      C2SafepointPollStub* stub = new (C->comp_arena()) C2SafepointPollStub(__ offset());
+      C->output()->add_stub(stub);
+      code_stub = &stub->entry();
       __ relocate(relocInfo::poll_return_type);
     }
     __ safepoint_poll(*code_stub, temp, true /* at_return */, true /* in_nmethod */);


### PR DESCRIPTION
We already have back-ported the majority of 8297036: Generalize C2 stub mechanism, but are missing the PPC parts. Backporting those parts will fix PPC builds.

Testing:
 - [x] GHA PPC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308651](https://bugs.openjdk.org/browse/JDK-8308651): [Lilliput/JDK17] Cherry-pick PPC parts of 8297036: Generalize C2 stub mechanism


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/25.diff">https://git.openjdk.org/lilliput-jdk17u/pull/25.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/25#issuecomment-1559667673)