### PR TITLE
8308956: [Lilliput/JDK17] Fix some object initialization paths

### DIFF
--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -4021,14 +4021,16 @@ void TemplateTable::_new() {
 
     // initialize object header only.
     __ bind(initialize_header);
-    if (UseCompactObjectHeaders) {
+    if (UseBiasedLocking || UseCompactObjectHeaders) {
       __ pop(rcx);   // get saved klass back in the register.
       __ movptr(rbx, Address(rcx, Klass::prototype_header_offset()));
       __ movptr(Address(rax, oopDesc::mark_offset_in_bytes ()), rbx);
     } else {
-      __ movptr(Address(rax, oopDesc::mark_offset_in_bytes()),
+      __ movptr(Address(rax, oopDesc::mark_offset_in_bytes ()),
                 (intptr_t)markWord::prototype().value()); // header
       __ pop(rcx);   // get saved klass back in the register.
+    }
+    if (!UseCompactObjectHeaders) {
 #ifdef _LP64
       __ xorl(rsi, rsi); // use zero reg to clear memory (shorter code)
       __ store_klass_gap(rax, rsi);  // zero klass gap for compressed oops

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -426,7 +426,7 @@ void HeapShared::copy_roots() {
   memset(mem, 0, size * BytesPerWord);
   {
     // This is copied from MemAllocator::finish
-    if (UseCompactObjectHeaders) {
+    if (UseBiasedLocking || UseCompactObjectHeaders) {
       oopDesc::set_mark(mem, k->prototype_header());
     } else {
       oopDesc::set_mark(mem, markWord::prototype());

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -426,10 +426,14 @@ void HeapShared::copy_roots() {
   memset(mem, 0, size * BytesPerWord);
   {
     // This is copied from MemAllocator::finish
-    if (UseBiasedLocking || UseCompactObjectHeaders) {
+    if (UseBiasedLocking) {
       oopDesc::set_mark(mem, k->prototype_header());
+    } else if (UseCompactObjectHeaders) {
+      oopDesc::release_set_mark(mem, k->prototype_header());
     } else {
       oopDesc::set_mark(mem, markWord::prototype());
+    }
+    if (!UseCompactObjectHeaders) {
       oopDesc::release_set_klass(mem, k);
     }
   }

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -396,7 +396,6 @@ oop MemAllocator::finish(HeapWord* mem) const {
   // object zeroing are visible before setting the klass non-NULL, for
   // concurrent collectors.
   if (!UseCompactObjectHeaders) {
-    oopDesc::set_mark(mem, markWord::prototype());
     oopDesc::release_set_klass(mem, _klass);
   }
   return cast_to_oop(mem);

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -384,12 +384,18 @@ void MemAllocator::mem_clear(HeapWord* mem) const {
 
 oop MemAllocator::finish(HeapWord* mem) const {
   assert(mem != NULL, "NULL object pointer");
+  if (UseBiasedLocking) {
+    oopDesc::set_mark(mem, _klass->prototype_header());
+  } else if (UseCompactObjectHeaders) {
+    oopDesc::release_set_mark(mem, _klass->prototype_header());
+  } else {
+    // May be bootstrapping
+    oopDesc::set_mark(mem, markWord::prototype());
+  }
   // Need a release store to ensure array/class length, mark word, and
   // object zeroing are visible before setting the klass non-NULL, for
   // concurrent collectors.
-  if (UseCompactObjectHeaders) {
-    oopDesc::release_set_mark(mem, _klass->prototype_header());
-  } else {
+  if (!UseCompactObjectHeaders) {
     oopDesc::set_mark(mem, markWord::prototype());
     oopDesc::release_set_klass(mem, _klass);
   }

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -593,23 +593,23 @@ void ContiguousSpace::allocate_temporary_filler(int factor) {
     // allocate uninitialized int array
     typeArrayOop t = (typeArrayOop) cast_to_oop(allocate(size));
     assert(t != NULL, "allocation should succeed");
-#ifdef _LP64
-    t->set_mark(Universe::intArrayKlassObj()->prototype_header());
-#else
-    t->set_mark(markWord::prototype());
-    t->set_klass(Universe::intArrayKlassObj());
-#endif
+    if (UseCompactObjectHeaders) {
+      t->set_mark(Universe::intArrayKlassObj()->prototype_header());
+    } else {
+      t->set_mark(markWord::prototype());
+      t->set_klass(Universe::intArrayKlassObj());
+    }
     t->set_length((int)length);
   } else {
     assert(size == CollectedHeap::min_fill_size(),
            "size for smallest fake object doesn't match");
     instanceOop obj = (instanceOop) cast_to_oop(allocate(size));
-#ifdef _LP64
-    obj->set_mark(vmClasses::Object_klass()->prototype_header());
-#else
-    obj->set_mark(markWord::prototype());
-    obj->set_klass(vmClasses::Object_klass());
-#endif
+    if (UseCompactObjectHeaders) {
+      obj->set_mark(vmClasses::Object_klass()->prototype_header());
+    } else {
+      obj->set_mark(markWord::prototype());
+      obj->set_klass(vmClasses::Object_klass());
+    }
   }
 }
 

--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -1955,12 +1955,12 @@ run:
 
               // Initialize header
               assert(!UseBiasedLocking, "Not implemented");
-#ifdef _LP64
-              oopDesc::release_set_mark(result, ik->prototype_header());
-#else
-              obj->set_mark(markWord::prototype());
-              obj->set_klass(ik);
-#endif
+              if (UseCompactObjectHeaders) {
+                oopDesc::release_set_mark(result, ik->prototype_header());
+              } else {
+                obj->set_mark(markWord::prototype());
+                obj->set_klass(ik);
+              }
               // Must prevent reordering of stores for object initialization
               // with stores that publish the new object.
               OrderAccess::storestore();


### PR DESCRIPTION
In some object initialization paths I got the conditions wrong, especial wrt to biased-locking. Let's fix them.

Testing:
 - [x] tier1
 - [x] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308956](https://bugs.openjdk.org/browse/JDK-8308956): [Lilliput/JDK17] Fix some object initialization paths


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/28.diff">https://git.openjdk.org/lilliput-jdk17u/pull/28.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/28#issuecomment-1565319344)