### PR TITLE
8309192: [Lilliput/JDK17] Properly deal with flag mismatch in CDS

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -217,6 +217,7 @@ void FileMapHeader::populate(FileMapInfo* mapinfo, size_t core_region_alignment)
   _core_region_alignment = core_region_alignment;
   _obj_alignment = ObjectAlignmentInBytes;
   _compact_strings = CompactStrings;
+  _compact_headers = UseCompactObjectHeaders;
   if (HeapShared::is_heap_object_archiving_allowed()) {
     _narrow_oop_mode = CompressedOops::mode();
     _narrow_oop_base = CompressedOops::base();
@@ -279,6 +280,7 @@ void FileMapHeader::print(outputStream* st) {
   st->print_cr("- narrow_oop_base:                " INTPTR_FORMAT, p2i(_narrow_oop_base));
   st->print_cr("- narrow_oop_shift                %d", _narrow_oop_shift);
   st->print_cr("- compact_strings:                %d", _compact_strings);
+  st->print_cr("- compact_headers:                %d", _compact_headers);
   st->print_cr("- max_heap_size:                  " UINTX_FORMAT, _max_heap_size);
   st->print_cr("- narrow_oop_mode:                %d", _narrow_oop_mode);
   st->print_cr("- narrow_klass_shift:             %d", _narrow_klass_shift);
@@ -2282,6 +2284,14 @@ bool FileMapHeader::validate() {
   if (compressed_oops() != UseCompressedOops || compressed_class_pointers() != UseCompressedClassPointers) {
     FileMapInfo::fail_continue("Unable to use shared archive.\nThe saved state of UseCompressedOops and UseCompressedClassPointers is "
                                "different from runtime, CDS will be disabled.");
+    return false;
+  }
+
+  if (compact_headers() != UseCompactObjectHeaders) {
+    log_info(cds)("The shared archive file's UseCompactObjectHeaders setting (%s)"
+                  " does not equal the current UseCompactObjectHeaders setting (%s).",
+                  _compact_headers          ? "enabled" : "disabled",
+                  UseCompactObjectHeaders   ? "enabled" : "disabled");
     return false;
   }
 

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -193,6 +193,7 @@ class FileMapHeader: private CDSFileMapHeaderBase {
   address _narrow_oop_base;         // compressed oop encoding base
   int    _narrow_oop_shift;         // compressed oop encoding shift
   bool   _compact_strings;          // value of CompactStrings
+  bool   _compact_headers;          // value of UseCompactObjectHeaders
   uintx  _max_heap_size;            // java max heap size during dumping
   CompressedOops::Mode _narrow_oop_mode; // compressed oop encoding mode
   int     _narrow_klass_shift;      // save narrow klass base and shift
@@ -258,6 +259,7 @@ public:
   address narrow_oop_base()                const { return _narrow_oop_base; }
   int narrow_oop_shift()                   const { return _narrow_oop_shift; }
   bool compact_strings()                   const { return _compact_strings; }
+  bool compact_headers()                   const { return _compact_headers; }
   uintx max_heap_size()                    const { return _max_heap_size; }
   CompressedOops::Mode narrow_oop_mode()   const { return _narrow_oop_mode; }
   int narrow_klass_shift()                 const { return _narrow_klass_shift; }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3184,9 +3184,6 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
   if (UseCompactObjectHeaders && !UseAltGCForwarding) {
     FLAG_SET_DEFAULT(UseAltGCForwarding, true);
   }
-  if (!UseCompactObjectHeaders) {
-    FLAG_SET_DEFAULT(UseSharedSpaces, false);
-  }
 #endif
 
   return JNI_OK;

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3184,8 +3184,7 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
   if (UseCompactObjectHeaders && !UseAltGCForwarding) {
     FLAG_SET_DEFAULT(UseAltGCForwarding, true);
   }
-  if (UseCompactObjectHeaders) {
-    // Cannot use CDS with compact object headers yet
+  if (!UseCompactObjectHeaders) {
     FLAG_SET_DEFAULT(UseSharedSpaces, false);
   }
 #endif

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3184,7 +3184,8 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
   if (UseCompactObjectHeaders && !UseAltGCForwarding) {
     FLAG_SET_DEFAULT(UseAltGCForwarding, true);
   }
-  if (!UseCompactObjectHeaders) {
+  if (UseCompactObjectHeaders) {
+    // Cannot use CDS with compact object headers yet
     FLAG_SET_DEFAULT(UseSharedSpaces, false);
   }
 #endif

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -129,7 +129,7 @@ const size_t minimumSymbolTableSize = 1024;
           "Use 32-bit class pointers in 64-bit VM. "                        \
           "lp64_product means flag is always constant in 32 bit VM")        \
                                                                             \
-  product(bool, UseCompactObjectHeaders, true, EXPERIMENTAL,                \
+  product(bool, UseCompactObjectHeaders, false, EXPERIMENTAL,               \
                 "Use 64-bit object headers instead of 96-bit headers")      \
                                                                             \
   product(intx, ObjectAlignmentInBytes, 8,                                  \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -129,7 +129,7 @@ const size_t minimumSymbolTableSize = 1024;
           "Use 32-bit class pointers in 64-bit VM. "                        \
           "lp64_product means flag is always constant in 32 bit VM")        \
                                                                             \
-  product(bool, UseCompactObjectHeaders, false, EXPERIMENTAL,               \
+  product(bool, UseCompactObjectHeaders, true, EXPERIMENTAL,                \
                 "Use 64-bit object headers instead of 96-bit headers")      \
                                                                             \
   product(intx, ObjectAlignmentInBytes, 8,                                  \

--- a/test/hotspot/jtreg/runtime/cds/CdsDifferentCompactObjectHeaders.java
+++ b/test/hotspot/jtreg/runtime/cds/CdsDifferentCompactObjectHeaders.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test CdsDifferentCompactObjectHeaders
+ * @summary Testing CDS (class data sharing) using opposite compact object header settings.
+ *          Using different compact bject headers setting for each dump/load pair.
+ *          This is a negative test; using compact header setting for loading that
+ *          is different from compact headers for creating a CDS file
+ *          should fail when loading.
+ * @requires vm.cds
+ * @requires vm.bits == 64
+ * @library /test/lib
+ * @run driver CdsDifferentCompactObjectHeaders
+ */
+
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.Platform;
+
+public class CdsDifferentCompactObjectHeaders {
+
+    public static void main(String[] args) throws Exception {
+        createAndLoadSharedArchive(true, false);
+        createAndLoadSharedArchive(false, true);
+    }
+
+    // Parameters are object alignment expressed in bytes
+    private static void
+    createAndLoadSharedArchive(boolean createCompactHeaders, boolean loadCompactHeaders)
+    throws Exception {
+        String createCompactHeadersArg = "-XX:" + (createCompactHeaders ? "+" : "-") + "UseCompactObjectHeaders";
+        String loadCompactHeadersArg   = "-XX:" + (loadCompactHeaders   ? "+" : "-") + "UseCompactObjectHeaders";
+        String expectedErrorMsg =
+            String.format(
+            "The shared archive file's UseCompactObjectHeaders setting (%s)" +
+            " does not equal the current UseCompactObjectHeaders setting (%s)",
+            createCompactHeaders ? "enabled" : "disabled",
+            loadCompactHeaders   ? "enabled" : "disabled");
+
+        CDSTestUtils.createArchiveAndCheck("-XX:+UnlockExperimentalVMOptions", createCompactHeadersArg);
+
+        OutputAnalyzer out = CDSTestUtils.runWithArchive("-Xlog:cds", "-XX:+UnlockExperimentalVMOptions", loadCompactHeadersArg);
+        CDSTestUtils.checkExecExpectError(out, 1, expectedErrorMsg);
+    }
+}


### PR DESCRIPTION
See the discussion in the bug.

There is a problem that disabling Lilliput effectively disables CDS. I think for 17u we should disable UCOH by default, and disable CDS when UCOH is on. That is, keep the legacy configuration untouched, and let Lilliput pay the price, if any.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `runtime/cds`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309192](https://bugs.openjdk.org/browse/JDK-8309192): [Lilliput/JDK17] Properly deal with flag mismatch in CDS


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/29.diff">https://git.openjdk.org/lilliput-jdk17u/pull/29.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/29#issuecomment-1569999426)