### PR TITLE
8309197: [Lilliput/JDK17] Fix ObjectSampleMarker without Lilliput

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/chains/objectSampleMarker.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/objectSampleMarker.hpp
@@ -72,11 +72,16 @@ class ObjectSampleMarker : public StackObj {
     // identify sample objects during the reachability search from gc roots.
     assert(!obj->mark().is_marked(), "should only mark an object once");
 #ifdef _LP64
-    if (mark.has_displaced_mark_helper()) {
-      mark = mark.displaced_mark_helper();
-    }
+    if (UseCompactObjectHeaders) {
+      if (mark.has_displaced_mark_helper()) {
+        mark = mark.displaced_mark_helper();
+      }
+      obj->set_mark(markWord::prototype().set_marked().set_narrow_klass(mark.narrow_klass()));
+    } else
 #endif
-    obj->set_mark(markWord::prototype().set_marked() LP64_ONLY(.set_narrow_klass(mark.narrow_klass())));
+    {
+      obj->set_mark(markWord::prototype().set_marked());
+    }
     assert(obj->mark().is_marked(), "invariant");
   }
 };


### PR DESCRIPTION
The change in ObjectSampleMarker, a part of JFR, is incorrect when Lilliput is off. It would reach to `set_narrow_klass` and `narrow_klass` unconditionally, but that is only safe to do when `UseCompactObjectHeader` is on.

This would be caught by assert in `set_narrow_klass` and `narrow_klass` with `-UCOH`. AFAICS, this has a chance to corrupt the header in release bits, as it would copy only the parts of the mark word, and we might be just lucky those are the same bits. 

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `jdk/jfr/event/oldobject` with `-XX:-UseCompactObjectHeaders` (passes now)
 - [x] macos-aarch64-server-fastdebug, `jdk/jfr/event/oldobject` with `-XX:+UseCompactObjectHeaders` (still fails, with unrelated problems)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309197](https://bugs.openjdk.org/browse/JDK-8309197): [Lilliput/JDK17] Fix ObjectSampleMarker without Lilliput


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/30.diff">https://git.openjdk.org/lilliput-jdk17u/pull/30.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/30#issuecomment-1570045862)