### PR TITLE
8310042: [Lilliput/JDK17] ZGC fixes and cleanups

### DIFF
--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -296,7 +296,7 @@ void ZBarrierSetC2::clone_at_expansion(PhaseMacroExpand* phase, ArrayCopyNode* a
       assert(src_offset == dest_offset, "should be equal");
       jlong offset = src_offset->get_long();
       if (offset != arrayOopDesc::base_offset_in_bytes(T_OBJECT)) {
-        assert(!UseCompressedClassPointers, "should only happen without compressed class pointers");
+        assert(!UseCompressedClassPointers || UseCompactObjectHeaders, "should only happen without compressed class pointers or with compact object headers");
         assert((arrayOopDesc::base_offset_in_bytes(T_OBJECT) - offset) == BytesPerLong, "unexpected offset");
         length = phase->transform_later(new SubLNode(length, phase->longcon(1))); // Size is in longs
         src_offset = phase->longcon(arrayOopDesc::base_offset_in_bytes(T_OBJECT));

--- a/src/hotspot/share/gc/z/zLiveMap.inline.hpp
+++ b/src/hotspot/share/gc/z/zLiveMap.inline.hpp
@@ -144,11 +144,15 @@ inline void ZLiveMap::iterate_segment(ObjectClosure* cl, BitMap::idx_t segment, 
     // Calculate object address
     const uintptr_t addr = page_start + ((index / 2) << page_object_alignment_shift);
 
+    // Get the size of the object before calling the closure, which
+    // might overwrite the object in case we are relocating in-place.
+    const size_t size = ZUtils::object_size(addr);
+
     // Apply closure
     cl->do_object(ZOop::from_address(addr));
 
     // Find next bit after this object
-    const uintptr_t next_addr = align_up(addr + 1, 1 << page_object_alignment_shift);
+    const uintptr_t next_addr = align_up(addr + size, 1 << page_object_alignment_shift);
     const BitMap::idx_t next_index = ((next_addr - page_start) >> page_object_alignment_shift) * 2;
     if (next_index >= end_index) {
       // End of live map


### PR DESCRIPTION
In ZGC, we don't need to change zLiveMap.inline.hpp and can revert to upstream state. In zBarrierSetC2.cpp we need to relax an assert.

Testing:
- [x] hotspot_gc
- [x] tier -XX:+UseZGC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310042](https://bugs.openjdk.org/browse/JDK-8310042): [Lilliput/JDK17] ZGC fixes and cleanups (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/31.diff">https://git.openjdk.org/lilliput-jdk17u/pull/31.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/31#issuecomment-1591519318)