### PR TITLE
8310156: [Lilliput/JDK17] Specialize full-GC loops

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -30,6 +30,7 @@
 #include "gc/g1/g1FullCollector.inline.hpp"
 #include "gc/g1/g1FullGCAdjustTask.hpp"
 #include "gc/g1/g1FullGCCompactTask.hpp"
+#include "gc/g1/g1FullGCCompactionPoint.inline.hpp"
 #include "gc/g1/g1FullGCMarker.inline.hpp"
 #include "gc/g1/g1FullGCMarkTask.hpp"
 #include "gc/g1/g1FullGCPrepareTask.hpp"

--- a/src/hotspot/share/gc/g1/g1FullGCAdjustTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCAdjustTask.cpp
@@ -39,10 +39,11 @@
 #include "memory/iterator.inline.hpp"
 #include "runtime/atomic.hpp"
 
+template<bool ALT_FWD>
 class G1AdjustLiveClosure : public StackObj {
-  G1AdjustClosure* _adjust_closure;
+  G1AdjustClosure<ALT_FWD>* _adjust_closure;
 public:
-  G1AdjustLiveClosure(G1AdjustClosure* cl) :
+  G1AdjustLiveClosure(G1AdjustClosure<ALT_FWD>* cl) :
     _adjust_closure(cl) { }
 
   size_t apply(oop object) {
@@ -54,14 +55,10 @@ class G1AdjustRegionClosure : public HeapRegionClosure {
   G1FullCollector* _collector;
   G1CMBitMap* _bitmap;
   uint _worker_id;
- public:
-  G1AdjustRegionClosure(G1FullCollector* collector, uint worker_id) :
-    _collector(collector),
-    _bitmap(collector->mark_bitmap()),
-    _worker_id(worker_id) { }
 
-  bool do_heap_region(HeapRegion* r) {
-    G1AdjustClosure cl(_collector);
+  template<bool ALT_FWD>
+  bool do_heap_region_impl(HeapRegion* r) {
+    G1AdjustClosure<ALT_FWD> cl(_collector);
     if (r->is_humongous()) {
       // Special handling for humongous regions to get somewhat better
       // work distribution.
@@ -71,10 +68,24 @@ class G1AdjustRegionClosure : public HeapRegionClosure {
       // Closed archive regions never change references and only contain
       // references into other closed regions and are always live. Free
       // regions do not contain objects to iterate. So skip both.
-      G1AdjustLiveClosure adjust(&cl);
+      G1AdjustLiveClosure<ALT_FWD> adjust(&cl);
       r->apply_to_marked_objects(_bitmap, &adjust);
     }
     return false;
+  }
+
+public:
+  G1AdjustRegionClosure(G1FullCollector* collector, uint worker_id) :
+    _collector(collector),
+    _bitmap(collector->mark_bitmap()),
+    _worker_id(worker_id) { }
+
+  bool do_heap_region(HeapRegion* r) {
+    if (UseAltGCForwarding) {
+      return do_heap_region_impl<true>(r);
+    } else {
+      return do_heap_region_impl<false>(r);
+    }
   }
 };
 
@@ -83,13 +94,13 @@ G1FullGCAdjustTask::G1FullGCAdjustTask(G1FullCollector* collector) :
     _root_processor(G1CollectedHeap::heap(), collector->workers()),
     _references_done(false),
     _weak_proc_task(collector->workers()),
-    _hrclaimer(collector->workers()),
-    _adjust(collector) {
+    _hrclaimer(collector->workers()) {
   // Need cleared claim bits for the roots processing
   ClassLoaderDataGraph::clear_claimed_marks();
 }
 
-void G1FullGCAdjustTask::work(uint worker_id) {
+template<bool ALT_FWD>
+void G1FullGCAdjustTask::work_impl(uint worker_id) {
   Ticks start = Ticks::now();
   ResourceMark rm;
 
@@ -97,20 +108,29 @@ void G1FullGCAdjustTask::work(uint worker_id) {
   G1FullGCMarker* marker = collector()->marker(worker_id);
   marker->preserved_stack()->adjust_during_full_gc();
 
+  G1AdjustClosure<ALT_FWD> adjust(collector());
   // Adjust the weak roots.
   if (!Atomic::cmpxchg(&_references_done, false, true)) {
-    G1CollectedHeap::heap()->ref_processor_stw()->weak_oops_do(&_adjust);
+    G1CollectedHeap::heap()->ref_processor_stw()->weak_oops_do(&adjust);
   }
 
   AlwaysTrueClosure always_alive;
-  _weak_proc_task.work(worker_id, &always_alive, &_adjust);
+  _weak_proc_task.work(worker_id, &always_alive, &adjust);
 
-  CLDToOopClosure adjust_cld(&_adjust, ClassLoaderData::_claim_strong);
-  CodeBlobToOopClosure adjust_code(&_adjust, CodeBlobToOopClosure::FixRelocations);
-  _root_processor.process_all_roots(&_adjust, &adjust_cld, &adjust_code);
+  CLDToOopClosure adjust_cld(&adjust, ClassLoaderData::_claim_strong);
+  CodeBlobToOopClosure adjust_code(&adjust, CodeBlobToOopClosure::FixRelocations);
+  _root_processor.process_all_roots(&adjust, &adjust_cld, &adjust_code);
 
   // Now adjust pointers region by region
   G1AdjustRegionClosure blk(collector(), worker_id);
   G1CollectedHeap::heap()->heap_region_par_iterate_from_worker_offset(&blk, &_hrclaimer, worker_id);
   log_task("Adjust task", worker_id, start);
+}
+
+void G1FullGCAdjustTask::work(uint worker_id) {
+  if (UseAltGCForwarding) {
+    work_impl<true>(worker_id);
+  } else {
+    work_impl<false>(worker_id);
+  }
 }

--- a/src/hotspot/share/gc/g1/g1FullGCAdjustTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCAdjustTask.hpp
@@ -39,8 +39,9 @@ class G1FullGCAdjustTask : public G1FullGCTask {
   volatile bool            _references_done;
   WeakProcessor::Task      _weak_proc_task;
   HeapRegionClaimer        _hrclaimer;
-  G1AdjustClosure          _adjust;
 
+  template<bool ALT_FWD>
+  void work_impl(uint worker_id);
 public:
   G1FullGCAdjustTask(G1FullCollector* collector);
   void work(uint worker_id);

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -59,14 +59,15 @@ public:
   }
 };
 
-size_t G1FullGCCompactTask::G1CompactRegionClosure::apply(oop obj) {
+template<bool ALT_FWD>
+size_t G1FullGCCompactTask::G1CompactRegionClosure<ALT_FWD>::apply(oop obj) {
   size_t size = obj->size();
   if (!SlidingForwarding::is_forwarded(obj)) {
     // Object not moving
     return size;
   }
 
-  HeapWord* destination = cast_from_oop<HeapWord*>(SlidingForwarding::forwardee(obj));
+  HeapWord* destination = cast_from_oop<HeapWord*>(SlidingForwarding::forwardee<ALT_FWD>(obj));
 
   // copy object and reinit its mark
   HeapWord* obj_addr = cast_from_oop<HeapWord*>(obj);
@@ -81,8 +82,13 @@ size_t G1FullGCCompactTask::G1CompactRegionClosure::apply(oop obj) {
 void G1FullGCCompactTask::compact_region(HeapRegion* hr) {
   assert(!hr->is_pinned(), "Should be no pinned region in compaction queue");
   assert(!hr->is_humongous(), "Should be no humongous regions in compaction queue");
-  G1CompactRegionClosure compact(collector()->mark_bitmap());
-  hr->apply_to_marked_objects(collector()->mark_bitmap(), &compact);
+  if (UseAltGCForwarding) {
+    G1CompactRegionClosure<true> compact(collector()->mark_bitmap());
+    hr->apply_to_marked_objects(collector()->mark_bitmap(), &compact);
+  } else {
+    G1CompactRegionClosure<false> compact(collector()->mark_bitmap());
+    hr->apply_to_marked_objects(collector()->mark_bitmap(), &compact);
+  }
   // Clear the liveness information for this region if necessary i.e. if we actually look at it
   // for bitmap verification. Otherwise it is sufficient that we move the TAMS to bottom().
   if (G1VerifyBitmaps) {

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.hpp
@@ -48,6 +48,7 @@ public:
   void work(uint worker_id);
   void serial_compaction();
 
+  template<bool ALT_FWD>
   class G1CompactRegionClosure : public StackObj {
     G1CMBitMap* _bitmap;
 

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
@@ -51,7 +51,8 @@ public:
   bool is_initialized();
   void initialize(HeapRegion* hr, bool init_threshold);
   void update();
-  void forward(oop object, size_t size);
+  template<bool ALT_FWD>
+  inline void forward(oop object, size_t size);
   void add(HeapRegion* hr);
 
   HeapRegion* remove_last();

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.inline.hpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_G1_G1FULLGCCOMPACTIONPOINT_INLINE_HPP
+#define SHARE_GC_G1_G1FULLGCCOMPACTIONPOINT_INLINE_HPP
+
+#include "gc/g1/g1FullGCCompactionPoint.hpp"
+#include "gc/g1/heapRegion.hpp"
+#include "gc/shared/slidingForwarding.inline.hpp"
+#include "oops/oop.inline.hpp"
+
+template<bool ALT_FWD>
+void G1FullGCCompactionPoint::forward(oop object, size_t size) {
+  assert(_current_region != NULL, "Must have been initialized");
+
+  // Ensure the object fit in the current region.
+  while (!object_will_fit(size)) {
+    switch_region();
+  }
+
+  // Store a forwarding pointer if the object should be moved.
+  if (cast_from_oop<HeapWord*>(object) != _compaction_top) {
+    SlidingForwarding::forward_to<ALT_FWD>(object, cast_to_oop(_compaction_top));
+  } else {
+    assert(!SlidingForwarding::is_forwarded(object), "should not be forwarded");
+    /*
+    if (object->forwardee() != NULL) {
+      // Object should not move but mark-word is used so it looks like the
+      // object is forwarded. Need to clear the mark and it's no problem
+      // since it will be restored by preserved marks. There is an exception
+      // with BiasedLocking, in this case forwardee() will return NULL
+      // even if the mark-word is used. This is no problem since
+      // forwardee() will return NULL in the compaction phase as well.
+      object->init_mark();
+    } else {
+      // Make sure object has the correct mark-word set or that it will be
+      // fixed when restoring the preserved marks.
+      assert(object->mark() == markWord::prototype_for_klass(object->klass()) || // Correct mark
+             object->mark_must_be_preserved() || // Will be restored by PreservedMarksSet
+             (UseBiasedLocking && object->has_bias_pattern()), // Will be restored by BiasedLocking
+             "should have correct prototype obj: " PTR_FORMAT " mark: " PTR_FORMAT " prototype: " PTR_FORMAT,
+             p2i(object), object->mark().value(), markWord::prototype_for_klass(object->klass()).value());
+    }
+    assert(object->forwardee() == NULL, "should be forwarded to NULL");
+    */
+  }
+
+  // Update compaction values.
+  _compaction_top += size;
+  if (_compaction_top > _threshold) {
+    _threshold = _current_region->cross_threshold(_compaction_top - size, _compaction_top);
+  }
+}
+
+#endif // SHARE_GC_G1_G1FULLGCCOMPACTIONPOINT_INLINE_HPP

--- a/src/hotspot/share/gc/g1/g1FullGCOopClosures.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCOopClosures.hpp
@@ -77,6 +77,7 @@ public:
   virtual void do_cld(ClassLoaderData* cld);
 };
 
+template<bool ALT_FWD>
 class G1AdjustClosure : public BasicOopIterateClosure {
   G1FullCollector* _collector;
 

--- a/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
@@ -64,7 +64,8 @@ inline void G1MarkAndPushClosure::do_cld(ClassLoaderData* cld) {
   _marker->follow_cld(cld);
 }
 
-template <class T> inline void G1AdjustClosure::adjust_pointer(T* p) {
+template<bool ALT_FWD>
+template <class T> inline void G1AdjustClosure<ALT_FWD>::adjust_pointer(T* p) {
   T heap_oop = RawAccess<>::oop_load(p);
   if (CompressedOops::is_null(heap_oop)) {
     return;
@@ -91,13 +92,15 @@ template <class T> inline void G1AdjustClosure::adjust_pointer(T* p) {
   }
 
   // Forwarded, just update.
-  oop forwardee = SlidingForwarding::forwardee(obj);
+  oop forwardee = SlidingForwarding::forwardee<ALT_FWD>(obj);
   assert(G1CollectedHeap::heap()->is_in_reserved(forwardee), "should be in object space");
   RawAccess<IS_NOT_NULL>::oop_store(p, forwardee);
 }
 
-inline void G1AdjustClosure::do_oop(oop* p)       { do_oop_work(p); }
-inline void G1AdjustClosure::do_oop(narrowOop* p) { do_oop_work(p); }
+template<bool ALT_FWD>
+inline void G1AdjustClosure<ALT_FWD>::do_oop(oop* p)       { do_oop_work(p); }
+template<bool ALT_FWD>
+inline void G1AdjustClosure<ALT_FWD>::do_oop(narrowOop* p) { do_oop_work(p); }
 
 inline bool G1IsAliveClosure::do_object_b(oop p) {
   return _bitmap->is_marked(p) || _collector->is_skip_marking(p);

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -26,7 +26,7 @@
 #include "gc/g1/g1CollectedHeap.hpp"
 #include "gc/g1/g1ConcurrentMarkBitMap.inline.hpp"
 #include "gc/g1/g1FullCollector.inline.hpp"
-#include "gc/g1/g1FullGCCompactionPoint.hpp"
+#include "gc/g1/g1FullGCCompactionPoint.inline.hpp"
 #include "gc/g1/g1FullGCMarker.hpp"
 #include "gc/g1/g1FullGCOopClosures.inline.hpp"
 #include "gc/g1/g1FullGCPrepareTask.hpp"
@@ -157,20 +157,23 @@ void G1FullGCPrepareTask::G1CalculatePointersClosure::reset_region_metadata(Heap
   }
 }
 
-G1FullGCPrepareTask::G1PrepareCompactLiveClosure::G1PrepareCompactLiveClosure(G1FullGCCompactionPoint* cp) :
+template<bool ALT_FWD>
+G1FullGCPrepareTask::G1PrepareCompactLiveClosure<ALT_FWD>::G1PrepareCompactLiveClosure(G1FullGCCompactionPoint* cp) :
     _cp(cp) { }
 
-size_t G1FullGCPrepareTask::G1PrepareCompactLiveClosure::apply(oop object) {
+template<bool ALT_FWD>
+size_t G1FullGCPrepareTask::G1PrepareCompactLiveClosure<ALT_FWD>::apply(oop object) {
   size_t size = object->size();
-  _cp->forward(object, size);
+  _cp->forward<ALT_FWD>(object, size);
   return size;
 }
 
-size_t G1FullGCPrepareTask::G1RePrepareClosure::apply(oop obj) {
+template<bool ALT_FWD>
+size_t G1FullGCPrepareTask::G1RePrepareClosure<ALT_FWD>::apply(oop obj) {
   // We only re-prepare objects forwarded within the current region, so
   // skip objects that are already forwarded to another region.
   if (SlidingForwarding::is_forwarded(obj)) {
-    oop forwarded_to = SlidingForwarding::forwardee(obj);
+    oop forwarded_to = SlidingForwarding::forwardee<ALT_FWD>(obj);
     assert(forwarded_to != NULL, "must have forwardee");
     if (!_current->is_in(forwarded_to)) {
       return obj->size();
@@ -178,16 +181,22 @@ size_t G1FullGCPrepareTask::G1RePrepareClosure::apply(oop obj) {
   }
   // Get size and forward.
   size_t size = obj->size();
-  _cp->forward(obj, size);
+  _cp->forward<ALT_FWD>(obj, size);
 
   return size;
 }
 
 void G1FullGCPrepareTask::G1CalculatePointersClosure::prepare_for_compaction_work(G1FullGCCompactionPoint* cp,
                                                                                   HeapRegion* hr) {
-  G1PrepareCompactLiveClosure prepare_compact(cp);
-  hr->set_compaction_top(hr->bottom());
-  hr->apply_to_marked_objects(_bitmap, &prepare_compact);
+  if (UseAltGCForwarding) {
+    G1PrepareCompactLiveClosure<true> prepare_compact(cp);
+    hr->set_compaction_top(hr->bottom());
+    hr->apply_to_marked_objects(_bitmap, &prepare_compact);
+  } else {
+    G1PrepareCompactLiveClosure<false> prepare_compact(cp);
+    hr->set_compaction_top(hr->bottom());
+    hr->apply_to_marked_objects(_bitmap, &prepare_compact);
+  }
 }
 
 void G1FullGCPrepareTask::G1CalculatePointersClosure::prepare_for_compaction(HeapRegion* hr) {
@@ -200,7 +209,8 @@ void G1FullGCPrepareTask::G1CalculatePointersClosure::prepare_for_compaction(Hea
   prepare_for_compaction_work(_cp, hr);
 }
 
-void G1FullGCPrepareTask::prepare_serial_compaction() {
+template<bool ALT_FWD>
+void G1FullGCPrepareTask::prepare_serial_compaction_impl() {
   GCTraceTime(Debug, gc, phases) debug("Phase 2: Prepare Serial Compaction", collector()->scope()->timer());
   // At this point we know that no regions were completely freed by
   // the parallel compaction. That means that the last region of
@@ -224,12 +234,20 @@ void G1FullGCPrepareTask::prepare_serial_compaction() {
       cp->initialize(current, false);
     } else {
       assert(!current->is_humongous(), "Should be no humongous regions in compaction queue");
-      G1RePrepareClosure re_prepare(cp, current);
+      G1RePrepareClosure<ALT_FWD> re_prepare(cp, current);
       current->set_compaction_top(current->bottom());
       current->apply_to_marked_objects(collector()->mark_bitmap(), &re_prepare);
     }
   }
   cp->update();
+}
+
+void G1FullGCPrepareTask::prepare_serial_compaction() {
+  if (UseAltGCForwarding) {
+    prepare_serial_compaction_impl<true>();
+  } else {
+    prepare_serial_compaction_impl<false>();
+  }
 }
 
 bool G1FullGCPrepareTask::G1CalculatePointersClosure::freed_regions() {

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.hpp
@@ -42,6 +42,10 @@ protected:
 
   void set_freed_regions();
 
+private:
+  template<bool ALT_FWD>
+  void prepare_serial_compaction_impl();
+
 public:
   G1FullGCPrepareTask(G1FullCollector* collector);
   void work(uint worker_id);
@@ -74,6 +78,7 @@ protected:
     bool freed_regions();
   };
 
+  template<bool ALT_FWD>
   class G1PrepareCompactLiveClosure : public StackObj {
     G1FullGCCompactionPoint* _cp;
 
@@ -82,6 +87,7 @@ protected:
     size_t apply(oop object);
   };
 
+  template<bool ALT_FWD>
   class G1RePrepareClosure : public StackObj {
     G1FullGCCompactionPoint* _cp;
     HeapRegion* _current;

--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -276,18 +276,31 @@ void GenMarkSweep::mark_sweep_phase3() {
   // Need new claim bits for the pointer adjustment tracing.
   ClassLoaderDataGraph::clear_claimed_marks();
 
-  {
-    StrongRootsScope srs(0);
-
-    gch->full_process_roots(true,  // this is the adjust phase
-                            GenCollectedHeap::SO_AllCodeCache,
-                            false, // all roots
-                            &adjust_pointer_closure,
-                            &adjust_cld_closure);
+  if (UseAltGCForwarding) {
+    AdjustPointerClosure<true> adjust_pointer_closure;
+    CLDToOopClosure adjust_cld_closure(&adjust_pointer_closure, ClassLoaderData::_claim_strong);
+    {
+      StrongRootsScope srs(0);
+      gch->full_process_roots(true,  // this is the adjust phase
+                              GenCollectedHeap::SO_AllCodeCache,
+                              false, // all roots
+                              &adjust_pointer_closure,
+                              &adjust_cld_closure);
+    }
+    gch->gen_process_weak_roots(&adjust_pointer_closure);
+  } else {
+    AdjustPointerClosure<false> adjust_pointer_closure;
+    CLDToOopClosure adjust_cld_closure(&adjust_pointer_closure, ClassLoaderData::_claim_strong);
+    {
+      StrongRootsScope srs(0);
+      gch->full_process_roots(true,  // this is the adjust phase
+                              GenCollectedHeap::SO_AllCodeCache,
+                              false, // all roots
+                              &adjust_pointer_closure,
+                              &adjust_cld_closure);
+    }
+    gch->gen_process_weak_roots(&adjust_pointer_closure);
   }
-
-  gch->gen_process_weak_roots(&adjust_pointer_closure);
-
   adjust_marks();
   GenAdjustPointersClosure blk;
   gch->generation_iterate(&blk, true);

--- a/src/hotspot/share/gc/serial/markSweep.cpp
+++ b/src/hotspot/share/gc/serial/markSweep.cpp
@@ -62,7 +62,6 @@ MarkSweep::FollowRootClosure  MarkSweep::follow_root_closure;
 
 MarkAndPushClosure MarkSweep::mark_and_push_closure;
 CLDToOopClosure    MarkSweep::follow_cld_closure(&mark_and_push_closure, ClassLoaderData::_claim_strong);
-CLDToOopClosure    MarkSweep::adjust_cld_closure(&adjust_pointer_closure, ClassLoaderData::_claim_strong);
 
 template <class T> inline void MarkSweep::KeepAliveClosure::do_oop_work(T* p) {
   mark_and_push(p);
@@ -144,8 +143,9 @@ template <class T> inline void MarkSweep::follow_root(T* p) {
 void MarkSweep::FollowRootClosure::do_oop(oop* p)       { follow_root(p); }
 void MarkSweep::FollowRootClosure::do_oop(narrowOop* p) { follow_root(p); }
 
+template<bool ALT_FWD>
 void PreservedMark::adjust_pointer() {
-  MarkSweep::adjust_pointer(&_obj);
+  MarkSweep::adjust_pointer<ALT_FWD>(&_obj);
 }
 
 void PreservedMark::restore() {
@@ -173,22 +173,29 @@ void MarkSweep::set_ref_processor(ReferenceProcessor* rp) {
   mark_and_push_closure.set_ref_discoverer(_ref_processor);
 }
 
-AdjustPointerClosure MarkSweep::adjust_pointer_closure;
-
+template<bool ALT_FWD>
 void MarkSweep::adjust_marks() {
   assert( _preserved_oop_stack.size() == _preserved_mark_stack.size(),
          "inconsistent preserved oop stacks");
 
   // adjust the oops we saved earlier
   for (size_t i = 0; i < _preserved_count; i++) {
-    _preserved_marks[i].adjust_pointer();
+    _preserved_marks[i].adjust_pointer<ALT_FWD>();
   }
 
   // deal with the overflow stack
   StackIterator<oop, mtGC> iter(_preserved_oop_stack);
   while (!iter.is_empty()) {
     oop* p = iter.next_addr();
-    adjust_pointer(p);
+    adjust_pointer<ALT_FWD>(p);
+  }
+}
+
+void MarkSweep::adjust_marks() {
+  if (UseAltGCForwarding) {
+    adjust_marks<true>();
+  } else {
+    adjust_marks<false>();
   }
 }
 

--- a/src/hotspot/share/gc/serial/markSweep.hpp
+++ b/src/hotspot/share/gc/serial/markSweep.hpp
@@ -50,7 +50,6 @@ class STWGCTimer;
 // declared at end
 class PreservedMark;
 class MarkAndPushClosure;
-class AdjustPointerClosure;
 
 class MarkSweep : AllStatic {
   //
@@ -84,7 +83,6 @@ class MarkSweep : AllStatic {
   //
   // Friend decls
   //
-  friend class AdjustPointerClosure;
   friend class KeepAliveClosure;
   friend class VM_MarkSweep;
 
@@ -124,8 +122,6 @@ class MarkSweep : AllStatic {
   static MarkAndPushClosure   mark_and_push_closure;
   static FollowStackClosure   follow_stack_closure;
   static CLDToOopClosure      follow_cld_closure;
-  static AdjustPointerClosure adjust_pointer_closure;
-  static CLDToOopClosure      adjust_cld_closure;
 
   // Accessors
   static uint total_invocations() { return _total_invocations; }
@@ -139,9 +135,12 @@ class MarkSweep : AllStatic {
 
   static void preserve_mark(oop p, markWord mark);
                                 // Save the mark word so it can be restored later
+  template<bool ALT_FWD>
+  static void adjust_marks();   // Adjust the pointers in the preserved marks table
   static void adjust_marks();   // Adjust the pointers in the preserved marks table
   static void restore_marks();  // Restore the marks that we saved in preserve_mark
 
+  template<bool ALT_FWD>
   static int adjust_pointers(oop obj);
 
   static void follow_stack();   // Empty marking stack.
@@ -150,7 +149,8 @@ class MarkSweep : AllStatic {
 
   static void follow_cld(ClassLoaderData* cld);
 
-  template <class T> static inline void adjust_pointer(T* p);
+  template <bool ALT_FWD, class T>
+  static inline void adjust_pointer(T* p);
 
   // Check mark and maybe push on marking stack
   template <class T> static void mark_and_push(T* p);
@@ -185,6 +185,7 @@ public:
   }
 };
 
+template<bool ALT_FWD>
 class AdjustPointerClosure: public BasicOopIterateClosure {
  public:
   template <typename T> void do_oop_work(T* p);
@@ -204,6 +205,7 @@ public:
     _mark = mark;
   }
 
+  template<bool ALT_FWD>
   void adjust_pointer();
   void restore();
 };

--- a/src/hotspot/share/gc/serial/markSweep.inline.hpp
+++ b/src/hotspot/share/gc/serial/markSweep.inline.hpp
@@ -87,14 +87,15 @@ inline void MarkAndPushClosure::do_oop(narrowOop* p)         { do_oop_work(p); }
 inline void MarkAndPushClosure::do_klass(Klass* k)           { MarkSweep::follow_klass(k); }
 inline void MarkAndPushClosure::do_cld(ClassLoaderData* cld) { MarkSweep::follow_cld(cld); }
 
-template <class T> inline void MarkSweep::adjust_pointer(T* p) {
+template <bool ALT_FWD, class T>
+inline void MarkSweep::adjust_pointer(T* p) {
   T heap_oop = RawAccess<>::oop_load(p);
   if (!CompressedOops::is_null(heap_oop)) {
     oop obj = CompressedOops::decode_not_null(heap_oop);
     assert(Universe::heap()->is_in(obj), "should be in heap");
 
     if (SlidingForwarding::is_forwarded(obj)) {
-      oop new_obj = SlidingForwarding::forwardee(obj);
+      oop new_obj = SlidingForwarding::forwardee<ALT_FWD>(obj);
       assert(new_obj != NULL, "must be forwarded");
       assert(is_object_aligned(new_obj), "oop must be aligned");
       RawAccess<IS_NOT_NULL>::oop_store(p, new_obj);
@@ -102,14 +103,20 @@ template <class T> inline void MarkSweep::adjust_pointer(T* p) {
   }
 }
 
+template <bool ALT_FWD>
 template <typename T>
-void AdjustPointerClosure::do_oop_work(T* p)           { MarkSweep::adjust_pointer(p); }
-inline void AdjustPointerClosure::do_oop(oop* p)       { do_oop_work(p); }
-inline void AdjustPointerClosure::do_oop(narrowOop* p) { do_oop_work(p); }
+void AdjustPointerClosure<ALT_FWD>::do_oop_work(T* p)           { MarkSweep::adjust_pointer<ALT_FWD>(p); }
 
+template <bool ALT_FWD>
+inline void AdjustPointerClosure<ALT_FWD>::do_oop(oop* p)       { do_oop_work(p); }
 
+template <bool ALT_FWD>
+inline void AdjustPointerClosure<ALT_FWD>::do_oop(narrowOop* p) { do_oop_work(p); }
+
+template <bool ALT_FWD>
 inline int MarkSweep::adjust_pointers(oop obj) {
-  return obj->oop_iterate_size(&MarkSweep::adjust_pointer_closure);
+  AdjustPointerClosure<ALT_FWD> adjust_pointer_closure;
+  return obj->oop_iterate_size(&adjust_pointer_closure);
 }
 
 #endif // SHARE_GC_SERIAL_MARKSWEEP_INLINE_HPP

--- a/src/hotspot/share/gc/shared/preservedMarks.cpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.cpp
@@ -40,15 +40,24 @@ void PreservedMarks::restore() {
   assert_empty();
 }
 
-void PreservedMarks::adjust_during_full_gc() {
+template<bool ALT_FWD>
+void PreservedMarks::adjust_during_full_gc_impl() {
   StackIterator<OopAndMarkWord, mtGC> iter(_stack);
   while (!iter.is_empty()) {
     OopAndMarkWord* elem = iter.next_addr();
 
     oop obj = elem->get_oop();
     if (SlidingForwarding::is_forwarded(obj)) {
-      elem->set_oop(SlidingForwarding::forwardee(obj));
+      elem->set_oop(SlidingForwarding::forwardee<ALT_FWD>(obj));
     }
+  }
+}
+
+void PreservedMarks::adjust_during_full_gc() {
+  if (UseAltGCForwarding) {
+    adjust_during_full_gc_impl<true>();
+  } else {
+    adjust_during_full_gc_impl<false>();
   }
 }
 

--- a/src/hotspot/share/gc/shared/preservedMarks.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.hpp
@@ -54,6 +54,9 @@ private:
 
   inline bool should_preserve_mark(oop obj, markWord m) const;
 
+  template<bool ALT_FWD>
+  void adjust_during_full_gc_impl();
+
 public:
   size_t size() const { return _stack.size(); }
   inline void push(oop obj, markWord m);

--- a/src/hotspot/share/gc/shared/slidingForwarding.hpp
+++ b/src/hotspot/share/gc/shared/slidingForwarding.hpp
@@ -179,7 +179,9 @@ public:
   static inline bool is_forwarded(oop obj);
   static inline bool is_not_forwarded(oop obj);
 
+  template<bool ALT_FWD>
   static inline void forward_to(oop from, oop to);
+  template<bool ALT_FWD>
   static inline oop forwardee(oop from);
 };
 

--- a/src/hotspot/share/gc/shared/slidingForwarding.inline.hpp
+++ b/src/hotspot/share/gc/shared/slidingForwarding.inline.hpp
@@ -127,12 +127,13 @@ inline void SlidingForwarding::forward_to_impl(oop from, oop to) {
   }
 }
 
+template<bool ALT_FWD>
 inline void SlidingForwarding::forward_to(oop obj, oop fwd) {
 #ifdef _LP64
-  if (UseAltGCForwarding) {
+  if (ALT_FWD) {
     assert(_bases_table != nullptr, "expect sliding forwarding initialized");
     forward_to_impl(obj, fwd);
-    assert(forwardee(obj) == fwd, "must be forwarded to correct forwardee");
+    assert(forwardee<ALT_FWD>(obj) == fwd, "must be forwarded to correct forwardee");
   } else
 #endif
   {
@@ -154,9 +155,10 @@ inline oop SlidingForwarding::forwardee_impl(oop from) {
   return cast_to_oop(to);
 }
 
+template<bool ALT_FWD>
 inline oop SlidingForwarding::forwardee(oop obj) {
 #ifdef _LP64
-  if (UseAltGCForwarding) {
+  if (ALT_FWD) {
     assert(_bases_table != nullptr, "expect sliding forwarding initialized");
     return forwardee_impl(obj);
   } else

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -347,6 +347,7 @@ void CompactibleSpace::clear(bool mangle_space) {
   _compaction_top = bottom();
 }
 
+template<bool ALT_FWD>
 HeapWord* CompactibleSpace::forward(oop q, size_t size,
                                     CompactPoint* cp, HeapWord* compact_top) {
   // q is alive
@@ -371,7 +372,7 @@ HeapWord* CompactibleSpace::forward(oop q, size_t size,
 
   // store the forwarding pointer into the mark word
   if (cast_from_oop<HeapWord*>(q) != compact_top) {
-    SlidingForwarding::forward_to(q, cast_to_oop(compact_top));
+    SlidingForwarding::forward_to<ALT_FWD>(q, cast_to_oop(compact_top));
     assert(q->is_gc_marked(), "encoding the pointer should preserve the mark");
   } else {
     // if the object isn't moving we can just set the mark to the default
@@ -394,7 +395,11 @@ HeapWord* CompactibleSpace::forward(oop q, size_t size,
 #if INCLUDE_SERIALGC
 
 void ContiguousSpace::prepare_for_compaction(CompactPoint* cp) {
-  scan_and_forward(this, cp);
+  if (UseAltGCForwarding) {
+    scan_and_forward<true>(this, cp);
+  } else {
+    scan_and_forward<false>(this, cp);
+  }
 }
 
 void CompactibleSpace::adjust_pointers() {
@@ -403,11 +408,19 @@ void CompactibleSpace::adjust_pointers() {
     return;   // Nothing to do.
   }
 
-  scan_and_adjust_pointers(this);
+  if (UseAltGCForwarding) {
+    scan_and_adjust_pointers<true>(this);
+  } else {
+    scan_and_adjust_pointers<false>(this);
+  }
 }
 
 void CompactibleSpace::compact() {
-  scan_and_compact(this);
+  if (UseAltGCForwarding) {
+    scan_and_compact<true>(this);
+  } else {
+    scan_and_compact<false>(this);
+  }
 }
 
 #endif // INCLUDE_SERIALGC

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -431,7 +431,8 @@ public:
   // If the forwarding crosses "cp->threshold", invokes the "cross_threshold"
   // function of the then-current compaction space, and updates "cp->threshold
   // accordingly".
-  virtual HeapWord* forward(oop q, size_t size, CompactPoint* cp,
+  template<bool ALT_FWD>
+  HeapWord* forward(oop q, size_t size, CompactPoint* cp,
                     HeapWord* compact_top);
 
   // Return a size with adjustments as required of the space.
@@ -460,17 +461,17 @@ protected:
 
 #if INCLUDE_SERIALGC
   // Frequently calls adjust_obj_size().
-  template <class SpaceType>
+  template <bool ALT_FWD, class SpaceType>
   static inline void scan_and_adjust_pointers(SpaceType* space);
 #endif
 
   // Frequently calls obj_size().
-  template <class SpaceType>
+  template <bool ALT_FWD, class SpaceType>
   static inline void scan_and_compact(SpaceType* space);
 
   // Frequently calls scanned_block_is_obj() and scanned_block_size().
   // Requires the scan_limit() function.
-  template <class SpaceType>
+  template <bool ALT_FWD, class SpaceType>
   static inline void scan_and_forward(SpaceType* space, CompactPoint* cp);
 };
 
@@ -481,7 +482,7 @@ class GenSpaceMangler;
 class ContiguousSpace: public CompactibleSpace {
   friend class VMStructs;
   // Allow scan_and_forward function to call (private) overrides for auxiliary functions on this class
-  template <typename SpaceType>
+  template <bool ALT_FWD, typename SpaceType>
   friend void CompactibleSpace::scan_and_forward(SpaceType* space, CompactPoint* cp);
 
  private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.hpp
@@ -55,6 +55,7 @@ class VM_ShenandoahFullGC;
 class ShenandoahDegenGC;
 
 class ShenandoahFullGC : public ShenandoahGC {
+  template<bool ALT_FWD>
   friend class ShenandoahPrepareForCompactionObjectClosure;
   friend class VM_ShenandoahFullGC;
   friend class ShenandoahDegenGC;
@@ -83,7 +84,11 @@ private:
   void phase4_compact_objects(ShenandoahHeapRegionSet** worker_slices);
 
   void distribute_slices(ShenandoahHeapRegionSet** worker_slices);
+  template<bool ALT_FWD>
+  void calculate_target_humongous_objects_impl();
   void calculate_target_humongous_objects();
+  template<bool ALT_FWD>
+  void compact_humongous_objects_impl();
   void compact_humongous_objects();
 };
 

--- a/test/hotspot/gtest/gc/shared/test_slidingForwarding.cpp
+++ b/test/hotspot/gtest/gc/shared/test_slidingForwarding.cpp
@@ -51,9 +51,9 @@ TEST_VM(SlidingForwarding, simple) {
   obj1->set_mark(markWord::prototype());
   SlidingForwarding::begin();
 
-  SlidingForwarding::forward_to(obj1, obj2);
+  SlidingForwarding::forward_to<true>(obj1, obj2);
   ASSERT_EQ(obj1->mark().value(), make_mark(0 /* target_region */, 0 /* offset */));
-  ASSERT_EQ(SlidingForwarding::forwardee(obj1), obj2);
+  ASSERT_EQ(SlidingForwarding::forwardee<true>(obj1), obj2);
 
   SlidingForwarding::end();
 }
@@ -70,13 +70,13 @@ TEST_VM(SlidingForwarding, tworegions) {
   obj1->set_mark(markWord::prototype());
   SlidingForwarding::begin();
 
-  SlidingForwarding::forward_to(obj1, obj2);
+  SlidingForwarding::forward_to<true>(obj1, obj2);
   ASSERT_EQ(obj1->mark().value(), make_mark(0 /* target_region */, 2 /* offset */));
-  ASSERT_EQ(SlidingForwarding::forwardee(obj1), obj2);
+  ASSERT_EQ(SlidingForwarding::forwardee<true>(obj1), obj2);
 
-  SlidingForwarding::forward_to(obj1, obj3);
+  SlidingForwarding::forward_to<true>(obj1, obj3);
   ASSERT_EQ(obj1->mark().value(), make_mark(1 /* target_region */, 2 /* offset */));
-  ASSERT_EQ(SlidingForwarding::forwardee(obj1), obj3);
+  ASSERT_EQ(SlidingForwarding::forwardee<true>(obj1), obj3);
 
   SlidingForwarding::end();
 }
@@ -101,21 +101,21 @@ TEST_VM(SlidingForwarding, fallback) {
   s_obj4->set_mark(markWord::prototype());
   SlidingForwarding::begin();
 
-  SlidingForwarding::forward_to(s_obj1, t_obj1);
+  SlidingForwarding::forward_to<true>(s_obj1, t_obj1);
   ASSERT_EQ(s_obj1->mark().value(), make_mark(0 /* target_region */, 2 /* offset */));
-  ASSERT_EQ(SlidingForwarding::forwardee(s_obj1), t_obj1);
+  ASSERT_EQ(SlidingForwarding::forwardee<true>(s_obj1), t_obj1);
 
-  SlidingForwarding::forward_to(s_obj2, t_obj2);
+  SlidingForwarding::forward_to<true>(s_obj2, t_obj2);
   ASSERT_EQ(s_obj2->mark().value(), make_mark(1 /* target_region */, 0 /* offset */));
-  ASSERT_EQ(SlidingForwarding::forwardee(s_obj2), t_obj2);
+  ASSERT_EQ(SlidingForwarding::forwardee<true>(s_obj2), t_obj2);
 
-  SlidingForwarding::forward_to(s_obj3, t_obj3);
+  SlidingForwarding::forward_to<true>(s_obj3, t_obj3);
   ASSERT_EQ(s_obj3->mark().value(), make_fallback());
-  ASSERT_EQ(SlidingForwarding::forwardee(s_obj3), t_obj3);
+  ASSERT_EQ(SlidingForwarding::forwardee<true>(s_obj3), t_obj3);
 
-  SlidingForwarding::forward_to(s_obj4, t_obj4);
+  SlidingForwarding::forward_to<true>(s_obj4, t_obj4);
   ASSERT_EQ(s_obj4->mark().value(), make_fallback());
-  ASSERT_EQ(SlidingForwarding::forwardee(s_obj4), t_obj4);
+  ASSERT_EQ(SlidingForwarding::forwardee<true>(s_obj4), t_obj4);
 
   SlidingForwarding::end();
 }


### PR DESCRIPTION
We already ported most of [JDK-8305896](https://bugs.openjdk.org/browse/JDK-8305896) to Lilliput/JDK17. What's missing is the specialization of the full-GC loops so that performance on the legacy path is not impacted and performance on the alt-GC-forwarding path is minimized.

Testing:
 - [x] hotspot_gc
 - [ ] tier1 -XX:+UseG1GC
 - [ ] tier1 -XX:+UseSerialGC
 - [ ] tier1 -XX:+UseShenandoahGC
 - [ ] tier2 -XX:+UseG1GC
 - [ ] tier2 -XX:+UseSerialGC
 - [ ] tier2 -XX:+UseShenandoahGC