### PR TITLE
8310231: [Lilliput/JDK17] Disable compact headers by default

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -125,7 +125,7 @@ const size_t minimumSymbolTableSize = 1024;
           "Use 32-bit object references in 64-bit VM. "                     \
           "lp64_product means flag is always constant in 32 bit VM")        \
                                                                             \
-  product(bool, UseCompressedClassPointers, false,                          \
+  product(bool, UseCompressedClassPointers, true,                           \
           "Use 32-bit class pointers in 64-bit VM. "                        \
           "lp64_product means flag is always constant in 32 bit VM")        \
                                                                             \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -125,12 +125,12 @@ const size_t minimumSymbolTableSize = 1024;
           "Use 32-bit object references in 64-bit VM. "                     \
           "lp64_product means flag is always constant in 32 bit VM")        \
                                                                             \
-  product(bool, UseCompressedClassPointers, true,                           \
+  product(bool, UseCompressedClassPointers, false,                          \
           "Use 32-bit class pointers in 64-bit VM. "                        \
           "lp64_product means flag is always constant in 32 bit VM")        \
                                                                             \
-  product(bool, UseCompactObjectHeaders, true, EXPERIMENTAL,                \
-                "Use 64-bit object headers instead of 96-bit headers")      \
+  product(bool, UseCompactObjectHeaders, false, EXPERIMENTAL,               \
+          "Use 64-bit object headers instead of 96-bit headers")            \
                                                                             \
   product(intx, ObjectAlignmentInBytes, 8,                                  \
           "Default object alignment in bytes, 8 is minimum")                \

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -524,7 +524,11 @@ public class VMProps implements Callable<Map<String, String>> {
                 // added by run-test framework
                 "MaxRAMPercentage",
                 // added by test environment
-                "CreateCoredumpOnCrash"
+                "CreateCoredumpOnCrash",
+                // experimental features unlocking flag does not affect behavior
+                "UnlockExperimentalVMOptions",
+                // all compact headers settings should run flagless tests
+                "UseCompactObjectHeaders"
         );
         result &= allFlags.stream()
                           .filter(s -> s.startsWith("-XX:"))


### PR DESCRIPTION
Same as https://github.com/openjdk/lilliput/pull/99.

Note that I also reverted the change to `UseCompressedClassPointers`, for extra safety.

Additional testing:
 - [x] Checked sample `@flagless` tests run with/without `UCOH`
 - [x] Linux AArch64 tier1, out of box
 - [x] Linux AArch64 tier1, `-XX:+UnlockExperimentalVMOptions -XX:+UseCompactObjectHeaders`
 - [x] Linux AArch64 tier1, `-XX:+UnlockExperimentalVMOptions -XX:-UseCompactObjectHeaders`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310231](https://bugs.openjdk.org/browse/JDK-8310231): [Lilliput/JDK17] Disable compact headers by default (**Enhancement** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to [df9abf7b](https://git.openjdk.org/lilliput-jdk17u/pull/33/files/df9abf7bb8a95820affeaf7093e1d38456cf2975)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/33.diff">https://git.openjdk.org/lilliput-jdk17u/pull/33.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/33#issuecomment-1594955246)