### PR TITLE
8310534: [Lilliput/JDK17] Shenandoah/JVMTI heap-walk crashes

### DIFF
--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -1467,10 +1467,7 @@ inline void ObjectMarker::mark(oop o) {
   }
 
   // mark the object
-  if (mark.has_displaced_mark_helper()) {
-    mark = mark.displaced_mark_helper();
-  }
-  o->set_mark(mark.set_marked());
+  o->set_mark(markWord::prototype().set_marked());
 }
 
 // return true if object is marked


### PR DESCRIPTION
I observe a crash in JVMTI heap-walk code when running Shenandoah even with -UCOH, see bug report for details.

The fix for now is to revert the relevant change back to clean upstream state. The JVMTI heap-dump would be disabled with +UCOH anyway in #35, and eventually fixed properly by #21.

Testing:
 - [x] serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java TEST_VM_OPTS="-XX:+UseShenandoahGC"
 - [x] tier1 with TEST_VM_OPTS="-XX:+UseShenandoahGC"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310534](https://bugs.openjdk.org/browse/JDK-8310534): [Lilliput/JDK17] Shenandoah/JVMTI heap-walk crashes (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/37.diff">https://git.openjdk.org/lilliput-jdk17u/pull/37.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/37#issuecomment-1600885717)