### PR TITLE
8310531: [Lilliput/JDK17] Revert unnecessary test code modifications and fix the tests

### DIFF
--- a/test/hotspot/gtest/oops/test_typeArrayOop.cpp
+++ b/test/hotspot/gtest/oops/test_typeArrayOop.cpp
@@ -36,9 +36,14 @@ TEST_VM(typeArrayOopDesc, bool_at_put) {
   char* addr = align_up(mem, 16);
 
   typeArrayOop o = (typeArrayOop) cast_to_oop(addr);
-#ifndef _LP64
-  o->set_klass(Universe::boolArrayKlassObj());
+#ifdef _LP64
+  if (UseCompactObjectHeaders) {
+    o->set_mark(Universe::boolArrayKlassObj()->prototype_header());
+  } else
 #endif
+  {
+    o->set_klass(Universe::boolArrayKlassObj());
+  }
   o->set_length(10);
 
 

--- a/test/hotspot/jtreg/compiler/c1/TestArrayCopyToFromObject.java
+++ b/test/hotspot/jtreg/compiler/c1/TestArrayCopyToFromObject.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8160591
  * @summary C1-generated code for System.arraycopy() does not throw an ArrayStoreException if 'dst' is no a "proper" array (i.e., it is java.lang.Object)
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xcomp -XX:-UseCompressedClassPointers -XX:CompileOnly=TestArrayCopyToFromObject.test TestArrayCopyToFromObject
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xcomp -XX:+UseCompressedClassPointers -XX:CompileOnly=TestArrayCopyToFromObject.test TestArrayCopyToFromObject
  */
 public class TestArrayCopyToFromObject {

--- a/test/hotspot/jtreg/compiler/unsafe/OpaqueAccesses.java
+++ b/test/hotspot/jtreg/compiler/unsafe/OpaqueAccesses.java
@@ -33,7 +33,17 @@
  *                                 compiler.unsafe.OpaqueAccesses
  * @run main/bootclasspath/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                                 -XX:-TieredCompilation -Xbatch
+ *                                 -XX:+UseCompressedOops -XX:-UseCompressedClassPointers
+ *                                 -XX:CompileCommand=dontinline,compiler.unsafe.OpaqueAccesses::test*
+ *                                 compiler.unsafe.OpaqueAccesses
+ * @run main/bootclasspath/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                                 -XX:-TieredCompilation -Xbatch
  *                                 -XX:-UseCompressedOops -XX:+UseCompressedClassPointers
+ *                                 -XX:CompileCommand=dontinline,compiler.unsafe.OpaqueAccesses::test*
+ *                                 compiler.unsafe.OpaqueAccesses
+ * @run main/bootclasspath/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                                 -XX:-TieredCompilation -Xbatch
+ *                                 -XX:-UseCompressedOops -XX:-UseCompressedClassPointers
  *                                 -XX:CompileCommand=dontinline,compiler.unsafe.OpaqueAccesses::test*
  *                                 compiler.unsafe.OpaqueAccesses
  */

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
@@ -174,7 +174,7 @@ public class TestMetaspacePerfCounters {
     }
 
     private static boolean isUsingCompressedClassPointers() {
-        return Platform.is64bit() && !InputArguments.contains("-XX:-UseCompressedClassPointers") /*&& !InputArguments.contains("-XX:-UseCompactObjectHeaders") */;
+        return Platform.is64bit() && InputArguments.contains("-XX:+UseCompressedClassPointers");
     }
 
     private static long getMinCapacity(String ns) throws Exception {

--- a/test/hotspot/jtreg/gtest/MetaspaceUtilsGtests.java
+++ b/test/hotspot/jtreg/gtest/MetaspaceUtilsGtests.java
@@ -27,3 +27,14 @@
  *  are not tested explicitly in the standard gtests.
  *
  */
+
+/* @test
+ * @bug 8264008
+ * @summary Run metaspace utils related gtests with compressed class pointers off
+ * @requires vm.bits == 64
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.xml
+ * @requires vm.flagless
+ * @run main/native GTestWrapper --gtest_filter=MetaspaceUtils* -XX:-UseCompressedClassPointers
+ */

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -53,9 +53,6 @@ public class CompressedClassPointers {
 
     // CDS off, small heap, ccs size default (1G)
     // A small heap should allow us to place the ccs within the lower 32G and thus allow zero based encoding.
-    /* Lilliput: cannot work due to drastically reduced narrow klass pointer range (atm 2g and that may get
-       smaller still). There is an argument for improving CDS/CCS reservation and make it more likely to run
-       zero-based, but that logic has to be rethought.
     public static void smallHeapTest() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-XX:+UnlockDiagnosticVMOptions",
@@ -70,11 +67,9 @@ public class CompressedClassPointers {
         }
         output.shouldHaveExitValue(0);
     }
-     */
 
     // CDS off, small heap, ccs size explicitely set to 1G
     // A small heap should allow us to place the ccs within the lower 32G and thus allow zero based encoding.
-    /* Lilliput: See comment above.
     public static void smallHeapTestWith1G() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-XX:+UnlockDiagnosticVMOptions",
@@ -89,13 +84,10 @@ public class CompressedClassPointers {
         }
         output.shouldHaveExitValue(0);
     }
-    */
 
     // CDS off, a very large heap, ccs size left to 1G default.
     // We expect the ccs to be mapped somewhere far beyond the heap, such that it is not possible
     // to use zero based encoding.
-    /* Lilliput: I am not sure what the point of this test CCS reservation is independent from
-       heap. See below the desparate attempts to predict heap reservation on PPC. Why do we even care?
     public static void largeHeapTest() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-XX:+UnlockDiagnosticVMOptions",
@@ -116,13 +108,11 @@ public class CompressedClassPointers {
         }
         output.shouldHaveExitValue(0);
     }
-     */
 
     // Settings as in largeHeapTest() except for max heap size. We make max heap
     // size even larger such that it cannot fit into lower 32G but not too large
     // for compressed oops.
     // We expect a zerobased ccs.
-    /* Lilliput: narrow klass pointer range drastically reduced. See comments under smallHeapTest().
     public static void largeHeapAbove32GTest() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-XX:+UnlockDiagnosticVMOptions",
@@ -142,13 +132,8 @@ public class CompressedClassPointers {
         }
         output.shouldHaveExitValue(0);
     }
-    */
 
     // Using large paged heap, metaspace uses small pages.
-    /* Lilliput: not sure what the point of this test is. The ability to have a class space if heap uses
-       large pages? Why would that be a problem? Kept alive for now since it makes no problems even with
-       smaller class pointers.
-     */
     public static void largePagesForHeapTest() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
                 "-XX:+UnlockDiagnosticVMOptions",
@@ -209,7 +194,6 @@ public class CompressedClassPointers {
         }
     }
 
-    /* Lilliput: narrow klass pointer range drastically reduced. See comments under smallHeapTest().
     public static void smallHeapTestNoCoop() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-XX:-UseCompressedOops",
@@ -225,9 +209,7 @@ public class CompressedClassPointers {
         output.shouldContain("Narrow klass base: 0x0000000000000000");
         output.shouldHaveExitValue(0);
     }
-    */
 
-    /* Lilliput: narrow klass pointer range drastically reduced. See comments under smallHeapTest().
     public static void smallHeapTestWith1GNoCoop() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-XX:-UseCompressedOops",
@@ -247,9 +229,7 @@ public class CompressedClassPointers {
         }
         output.shouldHaveExitValue(0);
     }
-    */
 
-    /* Lilliput: narrow klass pointer range drastically reduced. See comments under smallHeapTest().
     public static void largeHeapTestNoCoop() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-XX:-UseCompressedOops",
@@ -269,7 +249,6 @@ public class CompressedClassPointers {
         }
         output.shouldHaveExitValue(0);
     }
-    */
 
     public static void largePagesTestNoCoop() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
@@ -338,10 +317,10 @@ public class CompressedClassPointers {
     }
 
     public static void main(String[] args) throws Exception {
-        // smallHeapTest();
-        // smallHeapTestWith1G();
-        // largeHeapTest();
-        // largeHeapAbove32GTest();
+        smallHeapTest();
+        smallHeapTestWith1G();
+        largeHeapTest();
+        largeHeapAbove32GTest();
         largePagesForHeapTest();
         heapBaseMinAddressTest();
         sharingTest();
@@ -353,9 +332,9 @@ public class CompressedClassPointers {
             // given an arbitrary address, that address occasionally collides
             // with where we would ideally have placed the compressed class
             // space. Therefore, macOS is omitted for now.
-            // smallHeapTestNoCoop();
-            // smallHeapTestWith1GNoCoop();
-            // largeHeapTestNoCoop();
+            smallHeapTestNoCoop();
+            smallHeapTestWith1GNoCoop();
+            largeHeapTestNoCoop();
             largePagesTestNoCoop();
             heapBaseMinAddressTestNoCoop();
             sharingTestNoCoop();

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassSpaceSize.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassSpaceSize.java
@@ -83,5 +83,13 @@ public class CompressedClassSpaceSize {
         output = new OutputAnalyzer(pb.start());
         output.shouldMatch("Compressed class space.*3221225472")
               .shouldHaveExitValue(0);
+
+
+        pb = ProcessTools.createJavaProcessBuilder("-XX:-UseCompressedClassPointers",
+                                                   "-XX:CompressedClassSpaceSize=1m",
+                                                   "-version");
+        output = new OutputAnalyzer(pb.start());
+        output.shouldContain("Setting CompressedClassSpaceSize has no effect when compressed class pointers are not used")
+              .shouldHaveExitValue(0);
     }
 }

--- a/test/hotspot/jtreg/runtime/FieldLayout/FieldDensityTest.java
+++ b/test/hotspot/jtreg/runtime/FieldLayout/FieldDensityTest.java
@@ -38,6 +38,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run main/othervm -XX:+UseCompressedOops -XX:+UseCompressedClassPointers FieldDensityTest
+ * @run main/othervm -XX:+UseCompressedOops -XX:-UseCompressedClassPointers FieldDensityTest
  */
 
 import java.lang.reflect.Field;

--- a/test/hotspot/jtreg/runtime/Metaspace/PrintMetaspaceDcmd.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/PrintMetaspaceDcmd.java
@@ -68,6 +68,26 @@ import jdk.test.lib.JDKToolFinder;
  */
 
 /*
+ * @test id=test-64bit-noccs
+ * @summary Test the VM.metaspace command
+ * @requires vm.bits == "64"
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run main/othervm -Dwithout-compressed-class-space -XX:MaxMetaspaceSize=201M -Xmx100M -XX:-UseCompressedOops -XX:-UseCompressedClassPointers PrintMetaspaceDcmd
+ */
+
+ /*
+ * @test id=test-nospecified
+ * @summary Test the VM.metaspace command
+ * @requires vm.bits == "64"
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run main/othervm -Dno-specified-flag -Xmx100M -XX:-UseCompressedOops -XX:-UseCompressedClassPointers PrintMetaspaceDcmd
+ */
+
+/*
  * @test test-32bit
  * @summary Test the VM.metaspace command
  * @requires vm.bits == "32"

--- a/test/hotspot/jtreg/runtime/Monitor/SyncOnValueBasedClassTest.java
+++ b/test/hotspot/jtreg/runtime/Monitor/SyncOnValueBasedClassTest.java
@@ -42,9 +42,13 @@ public class SyncOnValueBasedClassTest {
     static List<Object> testObjects = new ArrayList<Object>();
 
     private static final String[] specificFlags[] = {
+        {"-Xint", "-XX:+UseBiasedLocking"},
         {"-Xint", "-XX:-UseBiasedLocking"},
+        {"-Xcomp", "-XX:TieredStopAtLevel=1", "-XX:+UseBiasedLocking"},
         {"-Xcomp", "-XX:TieredStopAtLevel=1", "-XX:-UseBiasedLocking"},
         {"-Xcomp", "-XX:-TieredCompilation", "-XX:-UseBiasedLocking"},
+        {"-Xcomp", "-XX:-TieredCompilation", "-XX:+UseBiasedLocking", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:+UseOptoBiasInlining"},
+        {"-Xcomp", "-XX:-TieredCompilation", "-XX:+UseBiasedLocking", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:-UseOptoBiasInlining"}
     };
 
     private static void initTestObjects() {

--- a/test/hotspot/jtreg/runtime/cds/appcds/CommandLineFlagComboNegative.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/CommandLineFlagComboNegative.java
@@ -67,6 +67,8 @@ public class CommandLineFlagComboNegative {
         }
         testTable.add( new TestVector("-XX:+UseCompressedOops", "-XX:-UseCompressedOops",
             "The saved state of UseCompressedOops and UseCompressedClassPointers is different from runtime, CDS will be disabled.", 1) );
+        testTable.add( new TestVector("-XX:+UseCompressedClassPointers", "-XX:-UseCompressedClassPointers",
+           "The saved state of UseCompressedOops and UseCompressedClassPointers is different from runtime, CDS will be disabled.", 1) );
     }
 
     private void runTests() throws Exception

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestCombinedCompressedFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestCombinedCompressedFlags.java
@@ -46,10 +46,12 @@ public class TestCombinedCompressedFlags {
 
     static class ConfArg {
         public boolean useCompressedOops;            // UseCompressedOops
+        public boolean useCompressedClassPointers;   // UseCompressedClassPointers
         public String  msg;
         public int code;
-        public ConfArg(boolean useCompressedOops, String msg, int code) {
+        public ConfArg(boolean useCompressedOops, boolean useCompressedClassPointers, String msg, int code) {
             this.useCompressedOops = useCompressedOops;
+            this.useCompressedClassPointers = useCompressedClassPointers;
             this.msg  = msg;
             this.code = code;
         }
@@ -64,28 +66,65 @@ public class TestCombinedCompressedFlags {
         }
         private void initExecArgs() {
            /* The combinations have four cases.
-            *          UseCompressedOops   Result
+            *          UseCompressedOops   UseCompressedClassPointers  Result
             *    1.
-            *    dump: on
-            *    test: on                  Pass
-            *          off                 Fail
+            *    dump: on                  on
+            *    test: on                  on                          Pass
+            *          on                  off                         Fail
+            *          off                 on                          Fail
+            *          off                 off                         Fail
             *    2.
-            *    dump: off
-            *    test: off                 Pass
-            *          on                  Fail
+            *    dump: on                  off
+            *    test: on                  off                         Pass
+            *          on                  on                          Fail
+            *          off                 on                          Pass
+            *          off                 off                         Fail
+            *    3.
+            *    dump: off                 on
+            *    test: off                 on                          Pass
+            *          on                  on                          Fail
+            *          on                  off                         Fail
+            *    4.
+            *    dump: off                 off
+            *    test: off                 off                         Pass
+            *          on                  on                          Fail
+            *          on                  off                         Fail
             **/
             execArgs = new ArrayList<ConfArg>();
-            if (dumpArg.useCompressedOops) {
+            if (dumpArg.useCompressedOops && dumpArg.useCompressedClassPointers) {
                 execArgs
-                    .add(new ConfArg(true, HELLO_STRING, PASS));
+                    .add(new ConfArg(true, true, HELLO_STRING, PASS));
                 execArgs
-                    .add(new ConfArg(false, EXEC_ABNORMAL_MSG, FAIL));
+                    .add(new ConfArg(true, false, EXEC_ABNORMAL_MSG, FAIL));
+                execArgs
+                    .add(new ConfArg(false, true, EXEC_ABNORMAL_MSG, FAIL));
+                execArgs
+                    .add(new ConfArg(false, false, EXEC_ABNORMAL_MSG, FAIL));
 
-            } else if (!dumpArg.useCompressedOops) {
+            }  else if(dumpArg.useCompressedOops && !dumpArg.useCompressedClassPointers) {
                 execArgs
-                    .add(new ConfArg(false, HELLO_STRING, PASS));
+                    .add(new ConfArg(true, false, HELLO_STRING, PASS));
                 execArgs
-                    .add(new ConfArg(true, EXEC_ABNORMAL_MSG, FAIL));
+                    .add(new ConfArg(true, true, EXEC_ABNORMAL_MSG, FAIL));
+                execArgs
+                    .add(new ConfArg(false, true, EXEC_ABNORMAL_MSG, FAIL));
+                execArgs
+                    .add(new ConfArg(false, false, EXEC_ABNORMAL_MSG, FAIL));
+
+            } else if (!dumpArg.useCompressedOops && dumpArg.useCompressedClassPointers) {
+                execArgs
+                    .add(new ConfArg(false, true, HELLO_STRING, PASS));
+                execArgs
+                    .add(new ConfArg(true, true, EXEC_ABNORMAL_MSG, FAIL));
+                execArgs
+                    .add(new ConfArg(true, false, EXEC_ABNORMAL_MSG, FAIL));
+            } else if (!dumpArg.useCompressedOops && !dumpArg.useCompressedClassPointers) {
+                execArgs
+                    .add(new ConfArg(false, false, HELLO_STRING, PASS));
+                execArgs
+                    .add(new ConfArg(true, true, EXEC_ABNORMAL_MSG, FAIL));
+                execArgs
+                    .add(new ConfArg(true, false, EXEC_ABNORMAL_MSG, FAIL));
             }
         }
     }
@@ -95,14 +134,23 @@ public class TestCombinedCompressedFlags {
         else    return "-XX:-UseCompressedOops";
     }
 
+    public static String getCompressedClassPointersArg(boolean on) {
+        if (on) return "-XX:+UseCompressedClassPointers";
+        else    return "-XX:-UseCompressedClassPointers";
+    }
+
     public static List<RunArg> runList;
 
     public static void configureRunArgs() {
         runList = new ArrayList<RunArg>();
         runList
-            .add(new RunArg(new ConfArg(true, null, PASS)));
+            .add(new RunArg(new ConfArg(true, true, null, PASS)));
         runList
-            .add(new RunArg(new ConfArg(false, null, PASS)));
+            .add(new RunArg(new ConfArg(true, false, null, PASS)));
+        runList
+            .add(new RunArg(new ConfArg(false, true, null, PASS)));
+        runList
+            .add(new RunArg(new ConfArg(false, false, null, PASS)));
     }
 
     public static void main(String[] args) throws Exception {
@@ -114,6 +162,7 @@ public class TestCombinedCompressedFlags {
                 .dump(helloJar,
                       new String[] {"Hello"},
                       getCompressedOopsArg(t.dumpArg.useCompressedOops),
+                      getCompressedClassPointersArg(t.dumpArg.useCompressedClassPointers),
                       "-Xlog:cds",
                       "-XX:NativeMemoryTracking=detail");
             out.shouldContain("Dumping shared data to file:");
@@ -126,6 +175,7 @@ public class TestCombinedCompressedFlags {
                                       "-Xlog:cds",
                                       "-XX:NativeMemoryTracking=detail",
                                       getCompressedOopsArg(c.useCompressedOops),
+                                      getCompressedClassPointersArg(c.useCompressedClassPointers),
                                       "Hello");
                 out.shouldContain(c.msg);
                 out.shouldHaveExitValue(c.code);

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestZGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestZGCWithCDS.java
@@ -72,7 +72,19 @@ public class TestZGCWithCDS {
          out.shouldContain(ERR_MSG);
          out.shouldHaveExitValue(1);
 
-         System.out.println("3. Run with -UseCompressedOops +UseCompressedClassPointers");
+         System.out.println("3. Run with -UseCompressedOops -UseCompressedClassPointers");
+         out = TestCommon
+                   .exec(helloJar,
+                         "-XX:+UseSerialGC",
+                         "-XX:-UseCompressedOops",
+                         "-XX:-UseCompressedClassPointers",
+                         "-Xlog:cds",
+                         "Hello");
+         out.shouldContain(UNABLE_TO_USE_ARCHIVE);
+         out.shouldContain(ERR_MSG);
+         out.shouldHaveExitValue(1);
+
+         System.out.println("4. Run with -UseCompressedOops +UseCompressedClassPointers");
          out = TestCommon
                    .exec(helloJar,
                          "-XX:+UseSerialGC",
@@ -83,7 +95,19 @@ public class TestZGCWithCDS {
          out.shouldContain(HELLO);
          out.shouldHaveExitValue(0);
 
-         System.out.println("4. Run with +UseCompressedOops +UseCompressedClassPointers");
+         System.out.println("5. Run with +UseCompressedOops -UseCompressedClassPointers");
+         out = TestCommon
+                   .exec(helloJar,
+                         "-XX:+UseSerialGC",
+                         "-XX:+UseCompressedOops",
+                         "-XX:-UseCompressedClassPointers",
+                         "-Xlog:cds",
+                         "Hello");
+         out.shouldContain(UNABLE_TO_USE_ARCHIVE);
+         out.shouldContain(ERR_MSG);
+         out.shouldHaveExitValue(1);
+
+         System.out.println("6. Run with +UseCompressedOops +UseCompressedClassPointers");
          out = TestCommon
                    .exec(helloJar,
                          "-XX:+UseSerialGC",
@@ -95,7 +119,18 @@ public class TestZGCWithCDS {
          out.shouldContain(ERR_MSG);
          out.shouldHaveExitValue(1);
 
-         System.out.println("5. Run with ZGC");
+         System.out.println("7. Dump with -UseCompressedOops -UseCompressedClassPointers");
+         out = TestCommon
+                   .dump(helloJar,
+                         new String[] {"Hello"},
+                         "-XX:+UseSerialGC",
+                         "-XX:-UseCompressedOops",
+                         "-XX:+UseCompressedClassPointers",
+                         "-Xlog:cds");
+         out.shouldContain("Dumping shared data to file:");
+         out.shouldHaveExitValue(0);
+
+         System.out.println("8. Run with ZGC");
          out = TestCommon
                    .exec(helloJar,
                          "-XX:+UseZGC",

--- a/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
+++ b/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
@@ -313,6 +313,9 @@ public class GetObjectSizeIntrinsicsTest extends ASimpleInstrumentationTestCase 
     static final int LARGE_INT_ARRAY_SIZE = 1024*1024*1024 + 1024;
     static final int LARGE_OBJ_ARRAY_SIZE = (4096/(int)REF_SIZE)*1024*1024 + 1024;
 
+    static final boolean COMPACT_HEADERS = WhiteBox.getWhiteBox().getBooleanVMFlag("UseCompactObjectHeaders");
+    static final int HEADER_SIZE = COMPACT_HEADERS ? 8 : (Platform.is64bit() ? 16 : 8);
+
     final String mode;
 
     public GetObjectSizeIntrinsicsTest(String name, String mode) {
@@ -372,14 +375,14 @@ public class GetObjectSizeIntrinsicsTest extends ASimpleInstrumentationTestCase 
     }
 
     private void testSize_newObject() {
-        long expected = roundUp(8, OBJ_ALIGN);
+        long expected = roundUp(HEADER_SIZE, OBJ_ALIGN);
         for (int c = 0; c < ITERS; c++) {
             assertEquals(expected, fInst.getObjectSize(new Object()));
         }
     }
 
     private void testSize_localObject() {
-        long expected = roundUp(8, OBJ_ALIGN);
+        long expected = roundUp(HEADER_SIZE, OBJ_ALIGN);
         Object o = new Object();
         for (int c = 0; c < ITERS; c++) {
             assertEquals(expected, fInst.getObjectSize(o));
@@ -389,7 +392,7 @@ public class GetObjectSizeIntrinsicsTest extends ASimpleInstrumentationTestCase 
     static Object staticO = new Object();
 
     private void testSize_fieldObject() {
-        long expected = roundUp(8, OBJ_ALIGN);
+        long expected = roundUp(HEADER_SIZE, OBJ_ALIGN);
         for (int c = 0; c < ITERS; c++) {
             assertEquals(expected, fInst.getObjectSize(staticO));
         }

--- a/test/jdk/jdk/jfr/event/gc/objectcount/ObjectCountEventVerifier.java
+++ b/test/jdk/jdk/jfr/event/gc/objectcount/ObjectCountEventVerifier.java
@@ -70,8 +70,7 @@ public class ObjectCountEventVerifier {
     private static long expectedFooArraySize(long count) {
         boolean runsOn32Bit = System.getProperty("sun.arch.data.model").equals("32");
         int bytesPerWord = runsOn32Bit ? 4 : 8;
-        // length will be in klass-gap on 64 bits, extra field on 32 bits.
-        int objectHeaderSize = bytesPerWord * (runsOn32Bit ? 3 : 2);
+        int objectHeaderSize = bytesPerWord * 3; // length will be aligned on 64 bits
         int alignmentInOopArray = runsOn32Bit ? 4 : 0;
         int ptrSize = bytesPerWord;
         return objectHeaderSize + alignmentInOopArray + count * ptrSize;


### PR DESCRIPTION
I have walked through the diff against 17u upstream, and reverted the disabled tests that pass with both `+UCOH` and `-UCOH`, and fixes a few others to work with `+UCOH` correctly. This brings us very close to 17u upstream testing-wise.

Additional testing:
 - [x] Linux x86_64 fastdebug, `tier1` (default, `-UCOH`)
 - [x] Linux x86_64 fastdebug, `tier1` (`+UCOH`)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310531](https://bugs.openjdk.org/browse/JDK-8310531): [Lilliput/JDK17] Revert unnecessary test code modifications and fix the tests (**Enhancement** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/38.diff">https://git.openjdk.org/lilliput-jdk17u/pull/38.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/38#issuecomment-1600969684)