### PR TITLE
8310555: [Lilliput/JDK17] Revert innocuous changes against upstream

### DIFF
--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -754,10 +754,8 @@ void Klass::oop_print_on(oop obj, outputStream* st) {
      // print header
      obj->mark().print_on(st);
      st->cr();
-     if (UseCompactObjectHeaders) {
-       st->print(BULLET"prototype_header: " INTPTR_FORMAT, _prototype_header.value());
-       st->cr();
-     }
+     st->print(BULLET"prototype_header: " INTPTR_FORMAT, _prototype_header.value());
+     st->cr();
   }
 
   // print class

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -42,6 +42,7 @@
 //
 //  64 bits:
 //  --------
+//  unused:25 hash:31 -->| unused_gap:1   age:4    biased_lock:1 lock:2 (normal object)
 //  JavaThread*:54 epoch:2 unused_gap:1   age:4    biased_lock:1 lock:2 (biased object)
 //
 //  64 bits (with compact headers):

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -439,6 +439,8 @@ DeadlockCycle* ThreadService::find_deadlocks_at_safepoint(ThreadsList * t_list, 
             // blocked permanently. We record this as a deadlock.
             num_deadlocks++;
 
+            cycle->set_deadlock(true);
+
             // add this cycle to the deadlocks list
             if (deadlocks == NULL) {
               deadlocks = cycle;


### PR DESCRIPTION
The code trawl identified a few places where we diverge from upstream without reason. 

The only non-obvious change is reverting `set_deadlock(true)` thing. The results that method is setting is actually unused, see https://bugs.openjdk.org/browse/JDK-8268857.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310555](https://bugs.openjdk.org/browse/JDK-8310555): [Lilliput/JDK17] Revert innocuous changes against upstream (**Enhancement** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/39.diff">https://git.openjdk.org/lilliput-jdk17u/pull/39.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/39#issuecomment-1601033022)