### PR TITLE
8310558: [Lilliput/JDK17] Missing klass gap initialization in ContiguousSpace::allocate_temporary_filler

### DIFF
--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -621,6 +621,7 @@ void ContiguousSpace::allocate_temporary_filler(int factor) {
       obj->set_mark(vmClasses::Object_klass()->prototype_header());
     } else {
       obj->set_mark(markWord::prototype());
+      obj->set_klass_gap(0);
       obj->set_klass(vmClasses::Object_klass());
     }
   }

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -85,6 +85,8 @@ public:
   static inline void release_set_klass(HeapWord* mem, Klass* k);
 
   // For klass field compression
+  inline int klass_gap() const;
+  inline void set_klass_gap(int z);
   static inline void set_klass_gap(HeapWord* mem, int z);
 
   // size of object header, aligned to platform wordSize

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -168,11 +168,21 @@ void oopDesc::release_set_klass(HeapWord* mem, Klass* k) {
   }
 }
 
+int oopDesc::klass_gap() const {
+  assert(!UseCompactObjectHeaders, "don't get Klass* gap with compact headers");
+  return *(int*)(((intptr_t)this) + klass_gap_offset_in_bytes());
+}
+
 void oopDesc::set_klass_gap(HeapWord* mem, int v) {
   assert(!UseCompactObjectHeaders, "don't set Klass* gap with compact headers");
   if (UseCompressedClassPointers) {
     *(int*)(((char*)mem) + klass_gap_offset_in_bytes()) = v;
   }
+}
+
+void oopDesc::set_klass_gap(int v) {
+  assert(!UseCompactObjectHeaders, "don't set Klass* gap with compact headers");
+  set_klass_gap((HeapWord*)this, v);
 }
 
 bool oopDesc::is_a(Klass* k) const {


### PR DESCRIPTION
Minor thing, but still.

This is Lilliput JDK 17 specific, later versions have [JDK-8278568](https://bugs.openjdk.org/browse/JDK-8278568) refactoring.

We have missed the `set_klass_gap(0)` line in the patch here:

```
    } else {
      assert(size == CollectedHeap::min_fill_size(),
             "size for smallest fake object doesn't match");
      instanceOop obj = (instanceOop) cast_to_oop(allocate(size));
- obj->set_mark(markWord::prototype());
- obj->set_klass_gap(0);
- obj->set_klass(vmClasses::Object_klass());
+ if (UseCompactObjectHeaders) {
+ obj->set_mark(vmClasses::Object_klass()->prototype_header());
+ } else {
+ obj->set_mark(markWord::prototype());
+ obj->set_klass(vmClasses::Object_klass());
+ }
    }
  }
```

I had to restore the klass gap methods in `oop`, which also limits the impact we have on upstream code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310558](https://bugs.openjdk.org/browse/JDK-8310558): [Lilliput/JDK17] Missing klass gap initialization in ContiguousSpace::allocate_temporary_filler (**Bug** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/40.diff">https://git.openjdk.org/lilliput-jdk17u/pull/40.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/40#issuecomment-1601086873)