### PR TITLE
8310642: [Lilliput/JDK17] Remove unnecessary check in G1ParScanThreadState

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -422,10 +422,6 @@ oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const regio
   assert(region_attr.is_in_cset(),
          "Unexpected region attr type: %s", region_attr.get_type_str());
 
-  if (old_mark.is_marked()) {
-    // Already forwarded by somebody else, return forwardee.
-    return old->forwardee(old_mark);
-  }
   // Get the klass once.  We'll need it again later, and this avoids
   // re-decoding when it's compressed.
   Klass* klass;


### PR DESCRIPTION
G1ParScanThreadState::do_copy_to_survivor_space() has an unnecessary change against upstream:

 if (old_mark.is_marked()) {
    // Already forwarded by somebody else, return forwardee.
    return old->forwardee(old_mark);
  }

All callers of this method already do the same, so this only adds code and possible affects performance for no reason.

Testing:
 - [ ] hotspot_gc -UCOH
 - [ ] hotspot_gc +UCOH
 - [ ] tier1 -UCOH
 - [ ] tier1 +UCOH
 - [ ] tier2 -UCOH
 - [ ] tier2 +UCOH