### PR TITLE
8310662: [Lilliput/JDK17] Fix OptoRuntime::new_array_nozero_C

### DIFF
--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -304,15 +304,17 @@ JRT_BLOCK_ENTRY(void, OptoRuntime::new_array_nozero_C(Klass* array_type, int len
     // Zero array here if the caller is deoptimized.
     int size = TypeArrayKlass::cast(array_type)->oop_size(result);
     BasicType elem_type = TypeArrayKlass::cast(array_type)->element_type();
-    const size_t hs_bytes = arrayOopDesc::base_offset_in_bytes(elem_type);
-    // Align to next 8 bytes to avoid trashing arrays's length.
-    const size_t aligned_hs_bytes = align_up(hs_bytes, BytesPerLong);
+    size_t hs_bytes = arrayOopDesc::base_offset_in_bytes(elem_type);
+    assert(is_aligned(hs_bytes, BytesPerInt), "must be 4 byte aligned");
     HeapWord* obj = cast_from_oop<HeapWord*>(result);
-    if (aligned_hs_bytes > hs_bytes) {
-      Copy::zero_to_bytes(obj + hs_bytes, aligned_hs_bytes - hs_bytes);
+    if (!is_aligned(hs_bytes, BytesPerLong)) {
+      *reinterpret_cast<jint*>(reinterpret_cast<char*>(obj) + hs_bytes) = 0;
+      hs_bytes += BytesPerInt;
     }
+
     // Optimized zeroing.
-    const size_t aligned_hs = aligned_hs_bytes / HeapWordSize;
+    assert(is_aligned(hs_bytes, BytesPerLong), "must be 8-byte aligned");
+    const size_t aligned_hs = hs_bytes / BytesPerLong;
     Copy::fill_to_aligned_words(obj+aligned_hs, size-aligned_hs);
   }
 


### PR DESCRIPTION
There's a severe bug in OptoRuntime::new_array_nozero_C() where we could end up clearing other memory because we add a byte-sized offset to a pointer base:

```
    HeapWord* obj = cast_from_oop<HeapWord*>(result);
    if (aligned_hs_bytes > hs_bytes) {
      Copy::zero_to_bytes(obj + hs_bytes, aligned_hs_bytes - hs_bytes);
    }
```

This PR brings us to the same state as the proposed upstreaming PR https://github.com/openjdk/jdk/pull/11044 currently has.

Three possible improvements to this PR:
 - Is it even worth clearing the unaligned head? Could we use Copy::fill_to_bytes() instead, and rely on that routine to do the split?
 - Should we guard the paths with if (UCOH) ?
 - I'm trying to come up with a reproducer, because that problem doesn't seem to have been caught by tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310662](https://bugs.openjdk.org/browse/JDK-8310662): [Lilliput/JDK17] Fix OptoRuntime::new_array_nozero_C (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/43.diff">https://git.openjdk.org/lilliput-jdk17u/pull/43.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/43#issuecomment-1602953714)