### PR TITLE
8310715: [Lilliput/JDK17] Revert more non-Lilliput test adjustments

### DIFF
--- a/test/hotspot/jtreg/gc/stress/TestMultiThreadStressRSet.java
+++ b/test/hotspot/jtreg/gc/stress/TestMultiThreadStressRSet.java
@@ -49,7 +49,7 @@ import jdk.test.lib.Utils;
  *
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *   -XX:+UseG1GC -XX:G1SummarizeRSetStatsPeriod=100 -Xlog:gc
- *   -Xmx1100M -XX:G1HeapRegionSize=8m -XX:MaxGCPauseMillis=1000 gc.stress.TestMultiThreadStressRSet 60 16
+ *   -Xmx1G -XX:G1HeapRegionSize=8m -XX:MaxGCPauseMillis=1000 gc.stress.TestMultiThreadStressRSet 60 16
  *
  * @run main/othervm/timeout=700 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *   -XX:+UseG1GC -XX:G1SummarizeRSetStatsPeriod=100 -Xlog:gc

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
@@ -131,7 +131,8 @@ public class TestIRMatching {
                  BadFailOnConstraint.create(RunTests.class, "bad1(int)", 2, "Load")
         );
 
-        runCheck(BadFailOnConstraint.create(Loads.class, "load()", 1, 1, "Load"),
+        runCheck(new String[] {"-XX:+IgnoreUnrecognizedVMOptions", "-XX:-UseCompressedClassPointers"},
+                 BadFailOnConstraint.create(Loads.class, "load()", 1, 1, "Load"),
                  BadFailOnConstraint.create(Loads.class, "load()", 1, 3, "LoadI"),
                  BadCountsConstraint.create(Loads.class, "load()", 1, 1, 0),
                  BadCountsConstraint.create(Loads.class, "load()", 1, 2, 1,"Load"),


### PR DESCRIPTION
The diff against upstream shows there are a few test adjustment leftovers. These are not needed for -UCOH code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310715](https://bugs.openjdk.org/browse/JDK-8310715): [Lilliput/JDK17] Revert more non-Lilliput test adjustments (**Enhancement** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/45.diff">https://git.openjdk.org/lilliput-jdk17u/pull/45.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/45#issuecomment-1604029151)