### PR TITLE
8310733: [Lilliput/JDK17] Enter object_iterate_impl() RESOLVE path only when +UCOH

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -872,7 +872,7 @@ void HeapRegion::object_iterate_impl(ObjectClosure* blk) {
 }
 
 void HeapRegion::object_iterate(ObjectClosure* blk) {
-  if (G1CollectedHeap::heap()->collector_state()->in_full_gc()) {
+  if (!UseCompactObjectHeaders || G1CollectedHeap::heap()->collector_state()->in_full_gc()) {
     object_iterate_impl<false>(blk);
   } else {
     object_iterate_impl<true>(blk);

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -188,9 +188,9 @@ inline size_t HeapRegion::block_size(const HeapWord *addr) const {
 #ifdef _LP64
 #ifdef ASSERT
     if (RESOLVE) {
-      assert(!G1CollectedHeap::heap()->collector_state()->in_full_gc(), "Illegal/excessive resolve during full-GC");
+      assert(UseCompactObjectHeaders && !G1CollectedHeap::heap()->collector_state()->in_full_gc(), "Illegal/excessive resolve during full-GC");
     } else {
-      assert(G1CollectedHeap::heap()->collector_state()->in_full_gc() || !obj->is_forwarded(), "Missing resolve when forwarded during normal GC");
+      assert(!UseCompactObjectHeaders || G1CollectedHeap::heap()->collector_state()->in_full_gc() || !obj->is_forwarded(), "Missing resolve when forwarded during normal GC");
     }
 #endif
     if (RESOLVE && obj->is_forwarded()) {


### PR DESCRIPTION
In HeapRegion::object_iterate_impl() we currently enter the RESOLVE path when doing full-GC, regardless if it's +UCOH or -UCOH. We should only enter RESOLVE path with +UCOH.

Testing:
 - [x] hotspot_gc -UCOH
 - [x] hotspot_gc +UCOH

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310733](https://bugs.openjdk.org/browse/JDK-8310733): [Lilliput/JDK17] Enter object_iterate_impl() RESOLVE path only when +UCOH (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/46.diff">https://git.openjdk.org/lilliput-jdk17u/pull/46.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/46#issuecomment-1604254576)