### PR TITLE
8310744: [Lilliput/JDK17] Revert C1_MacroAssembler::initialize_header removal of BiasedLocking path

### DIFF
--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -181,11 +181,14 @@ void C1_MacroAssembler::try_allocate(Register obj, Register var_size_in_bytes, i
 
 void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register len, Register t1, Register t2) {
   assert_different_registers(obj, klass, len, t1, t2);
-  if (UseCompactObjectHeaders) {
+  if (UseCompactObjectHeaders || (UseBiasedLocking && !len->is_valid())) {
     movptr(t1, Address(klass, Klass::prototype_header_offset()));
     movptr(Address(obj, oopDesc::mark_offset_in_bytes()), t1);
   } else {
     movptr(Address(obj, oopDesc::mark_offset_in_bytes()), checked_cast<int32_t>(markWord::prototype().value()));
+  }
+
+  if (!UseCompactObjectHeaders) {
 #ifdef _LP64
     if (UseCompressedClassPointers) { // Take care not to kill klass
       movptr(t1, klass);


### PR DESCRIPTION
In x86 C1_MacroAssembler::initialize_header, we accidentally removed the BiasedLocking path that should reach the klass prototype header. This reshapes x86 code to aarch64 code shape, which does the right thing.

This is 17u-specific, as BiasedLocking is removed in later releases. 

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1 tier2` (default)
 - [x] Linux x86_64 fastdebug `tier1 tier2` (+UCOH)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310744](https://bugs.openjdk.org/browse/JDK-8310744): [Lilliput/JDK17] Revert C1_MacroAssembler::initialize_header removal of BiasedLocking path (**Enhancement** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/47.diff">https://git.openjdk.org/lilliput-jdk17u/pull/47.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/47#issuecomment-1604303478)