### PR TITLE
8310888: [Lilliput/JDK17] Revert deflation of dead object's monitors

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -391,7 +391,7 @@ HeapWord* HeapRegion::oops_on_memregion_seq_iterate_careful(MemRegion mr,
   while (true) {
     oop obj = cast_to_oop(cur);
     assert(oopDesc::is_oop(obj, true), "Not an oop at " PTR_FORMAT, p2i(cur));
-    assert(obj->klass_or_null() != NULL,
+    assert(UseCompactObjectHeaders || obj->klass_or_null() != NULL,
            "Unparsable heap at " PTR_FORMAT, p2i(cur));
 
     size_t size;
@@ -400,6 +400,9 @@ HeapWord* HeapRegion::oops_on_memregion_seq_iterate_careful(MemRegion mr,
 
     cur += size;
     if (!is_dead) {
+      assert(!UseCompactObjectHeaders || obj->klass_or_null() != NULL,
+           "Unparsable heap at " PTR_FORMAT, p2i(cur));
+
       // Process live object's references.
 
       // Non-objArrays are usually marked imprecise at the object

--- a/src/hotspot/share/gc/shared/oopStorage.inline.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.inline.hpp
@@ -31,7 +31,6 @@
 #include "metaprogramming/conditional.hpp"
 #include "metaprogramming/isConst.hpp"
 #include "oops/oop.hpp"
-#include "runtime/objectMonitor.hpp"
 #include "runtime/safepoint.hpp"
 #include "utilities/align.hpp"
 #include "utilities/count_trailing_zeros.hpp"
@@ -263,7 +262,6 @@ public:
       if (_is_alive->do_object_b(v)) {
         result = _f(ptr);
       } else {
-        ObjectMonitor::maybe_deflate_dead(ptr);
         *ptr = NULL;            // Clear dead value.
       }
     }

--- a/src/hotspot/share/gc/shared/weakProcessor.inline.hpp
+++ b/src/hotspot/share/gc/shared/weakProcessor.inline.hpp
@@ -65,7 +65,6 @@ public:
       _keep_alive->do_oop(p);
       ++_live;
     } else {
-      ObjectMonitor::maybe_deflate_dead(p);
       *p = NULL;
       ++_new_dead;
     }

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -600,22 +600,6 @@ bool ObjectMonitor::deflate_monitor() {
   return true;  // Success, ObjectMonitor has been deflated.
 }
 
-// We might access the dead object headers for parsable heap walk, make sure
-// headers are in correct shape, e.g. monitors deflated.
-void ObjectMonitor::maybe_deflate_dead(oop* p) {
-  oop obj = *p;
-  assert(obj != NULL, "must not yet been cleared");
-  markWord mark = obj->mark();
-  if (mark.has_monitor()) {
-    ObjectMonitor* monitor = mark.monitor();
-    if (p == monitor->_object.ptr_raw()) {
-      assert(monitor->object_peek() == obj, "lock object must match");
-      markWord dmw = monitor->header();
-      obj->set_mark(dmw);
-    }
-  }
-}
-
 // Install the displaced mark word (dmw) of a deflating ObjectMonitor
 // into the header of the object associated with the monitor. This
 // idempotent method is called by a thread that is deflating a

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -358,8 +358,6 @@ private:
   intx      complete_exit(JavaThread* current);
   bool      reenter(intx recursions, JavaThread* current);
 
-  static void maybe_deflate_dead(oop* p);
-
  private:
   void      AddWaiter(ObjectWaiter* waiter);
   void      INotify(JavaThread* current);


### PR DESCRIPTION
Testing:
 - [x] hotspot_gc
 - [ ] tier1
 - [ ] tier1 +UseShenandoahGC
 - [ ] tier1 +UseZGC
 - [ ] tier2
 - [ ] tier2 +UseShenandoahGC
 - [ ] tier2 +UseZGC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310888](https://bugs.openjdk.org/browse/JDK-8310888): [Lilliput/JDK17] Revert deflation of dead object's monitors (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/49.diff">https://git.openjdk.org/lilliput-jdk17u/pull/49.diff</a>

</details>
