### PR TITLE
8311866: [Lilliput/JDK17] Disallow accessing oop metadata vmStructs with +UCOH

### DIFF
--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -371,14 +371,4 @@ public:
   DEBUG_ONLY(bool get_UseG1GC();)
 };
 
-// Used by VMStructs when CompactObjectHeaders are enabled.
-// Should match the relevant parts from the real oopDesc.
-class fakeOopDesc {
-private:
-  union _metadata {
-    Klass *_klass;
-    narrowKlass _compressed_klass;
-  } _metadata;
-};
-
 #endif // SHARE_OOPS_OOP_HPP

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -371,4 +371,13 @@ public:
   DEBUG_ONLY(bool get_UseG1GC();)
 };
 
+// Used by vmStructs when CompactObjectHeaders are enabled
+class fakeOopDesc {
+private:
+  union _metadata {
+    Klass *_klass;
+    narrowKlass _compressed_klass;
+  } _metadata;
+}
+
 #endif // SHARE_OOPS_OOP_HPP

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -371,13 +371,14 @@ public:
   DEBUG_ONLY(bool get_UseG1GC();)
 };
 
-// Used by vmStructs when CompactObjectHeaders are enabled
+// Used by VMStructs when CompactObjectHeaders are enabled.
+// Should match the relevant parts from the real oopDesc.
 class fakeOopDesc {
 private:
   union _metadata {
     Klass *_klass;
     narrowKlass _compressed_klass;
   } _metadata;
-}
+};
 
 #endif // SHARE_OOPS_OOP_HPP

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -149,6 +149,9 @@
 #if INCLUDE_JFR
 #include "jfr/jfr.hpp"
 #endif
+#if INCLUDE_VM_STRUCTS
+#include "runtime/vmStructs.hpp"
+#endif
 
 // Initialization after module runtime initialization
 void universe_post_module_init();  // must happen after call_initPhase2
@@ -2831,6 +2834,11 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   if (Arguments::init_libraries_at_startup()) {
     convert_vm_init_libraries_to_agents();
   }
+
+  // should happen before any agent attaches and pokes into vmStructs
+#if INCLUDE_VM_STRUCTS
+  VMStructs::compact_headers_overrides();
+#endif
 
   // Launch -agentlib/-agentpath and converted -Xrun agents
   if (Arguments::init_agents_at_startup()) {

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -2836,9 +2836,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   }
 
   // should happen before any agent attaches and pokes into vmStructs
-#if INCLUDE_VM_STRUCTS
   VMStructs::compact_headers_overrides();
-#endif
 
   // Launch -agentlib/-agentpath and converted -Xrun agents
   if (Arguments::init_agents_at_startup()) {

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -2835,8 +2835,10 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
     convert_vm_init_libraries_to_agents();
   }
 
-  // should happen before any agent attaches and pokes into vmStructs
+  // Should happen before any agent attaches and pokes into vmStructs
+#if INCLUDE_VM_STRUCTS
   VMStructs::compact_headers_overrides();
+#endif
 
   // Launch -agentlib/-agentpath and converted -Xrun agents
   if (Arguments::init_agents_at_startup()) {

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -2837,7 +2837,9 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 
   // Should happen before any agent attaches and pokes into vmStructs
 #if INCLUDE_VM_STRUCTS
-  VMStructs::compact_headers_overrides();
+  if (UseCompactObjectHeaders) {
+    VMStructs::compact_headers_overrides();
+  }
 #endif
 
   // Launch -agentlib/-agentpath and converted -Xrun agents

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -3223,7 +3223,6 @@ void VMStructs::compact_headers_overrides() {
       if (strcmp(e->typeName, "oopDesc") == 0) {
         if ((strcmp(e->fieldName, "_metadata._klass") == 0) ||
             (strcmp(e->fieldName, "_metadata._compressed_klass") == 0)) {
-          printf("typeName: %s, fieldName: %s, OVERRIDING\n", e->typeName, e->fieldName);
           e->typeName = "cannot_touch_this_with_compact_headers_oopDesc";
         }
       }

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -142,6 +142,16 @@
 #include "opto/vectornode.hpp"
 #endif // COMPILER2
 
+// Used by VMStructs when CompactObjectHeaders are enabled.
+// Must match the relevant parts from the real oopDesc.
+class fakeOopDesc {
+private:
+  union _metadata {
+    Klass*      _klass;
+    narrowKlass _compressed_klass;
+  } _metadata;
+};
+
 // Note: the cross-product of (c1, c2, product, nonproduct, ...),
 // (nonstatic, static), and (unchecked, checked) has not been taken.
 // Only the macros currently needed have been defined.

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1242,6 +1242,8 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
       declare_type(objArrayOopDesc, arrayOopDesc)                         \
     declare_type(instanceOopDesc, oopDesc)                                \
                                                                           \
+  declare_toplevel_type(fakeOopDesc)                                      \
+                                                                          \
   /**************************************************/                    \
   /* MetadataOopDesc hierarchy (NOTE: some missing) */                    \
   /**************************************************/                    \
@@ -3207,26 +3209,26 @@ void vmStructs_init() {
 #endif // ASSERT
 
 void VMStructs::compact_headers_overrides() {
-  if (UseCompactObjectHeaders) {
-    // We cannot allow SA and other facilities to poke into VM internal fields
-    // expecting the class pointers there. This will crash in the best case,
-    // or yield incorrect execution in the worst case. This code hides the
-    // risky fields from external code by replacing their original container
-    // type to a fake one. The fake type should exist for VMStructs verification
-    // code to work.
+  if (!UseCompactObjectHeaders) return;
 
-    size_t len = localHotSpotVMStructsLength();
-    for (size_t off = 0; off < len; off++) {
-      VMStructEntry* e = &localHotSpotVMStructs[off];
-      if (e == nullptr) continue;
-      if (e->typeName == nullptr) continue;
-      if (e->fieldName == nullptr) continue;
+  // We cannot allow SA and other facilities to poke into VM internal fields
+  // expecting the class pointers there. This will crash in the best case,
+  // or yield incorrect execution in the worst case. This code hides the
+  // risky fields from external code by replacing their original container
+  // type to a fake one. The fake type should exist for VMStructs verification
+  // code to work.
 
-      if (strcmp(e->typeName, "oopDesc") == 0) {
-        if ((strcmp(e->fieldName, "_metadata._klass") == 0) ||
-            (strcmp(e->fieldName, "_metadata._compressed_klass") == 0)) {
-          e->typeName = "fakeOopDesc";
-        }
+  size_t len = localHotSpotVMStructsLength();
+  for (size_t off = 0; off < len; off++) {
+    VMStructEntry* e = &localHotSpotVMStructs[off];
+    if (e == nullptr) continue;
+    if (e->typeName == nullptr) continue;
+    if (e->fieldName == nullptr) continue;
+
+    if (strcmp(e->typeName, "oopDesc") == 0) {
+      if ((strcmp(e->fieldName, "_metadata._klass") == 0) ||
+          (strcmp(e->fieldName, "_metadata._compressed_klass") == 0)) {
+        e->typeName = "fakeOopDesc";
       }
     }
   }

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -3211,7 +3211,9 @@ void VMStructs::compact_headers_overrides() {
     // We cannot allow SA and other facilities to poke into VM internal fields
     // expecting the class pointers there. This will crash in the best case,
     // or yield incorrect execution in the worst case. This code hides the
-    // risky fields from SA by renaming them.
+    // risky fields from external code by replacing their original container
+    // type to a fake one. The fake type should exist for VMStructs verification
+    // code to work.
 
     size_t len = localHotSpotVMStructsLength();
     for (size_t off = 0; off < len; off++) {
@@ -3223,7 +3225,7 @@ void VMStructs::compact_headers_overrides() {
       if (strcmp(e->typeName, "oopDesc") == 0) {
         if ((strcmp(e->fieldName, "_metadata._klass") == 0) ||
             (strcmp(e->fieldName, "_metadata._compressed_klass") == 0)) {
-          e->typeName = "cannot_touch_this_with_compact_headers_oopDesc";
+          e->typeName = "fakeOopDesc";
         }
       }
     }

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -3219,7 +3219,7 @@ void vmStructs_init() {
 #endif // ASSERT
 
 void VMStructs::compact_headers_overrides() {
-  if (!UseCompactObjectHeaders) return;
+  assert(UseCompactObjectHeaders, "Should have been checked before");
 
   // We cannot allow SA and other facilities to poke into VM internal fields
   // expecting the class pointers there. This will crash in the best case,

--- a/src/hotspot/share/runtime/vmStructs.hpp
+++ b/src/hotspot/share/runtime/vmStructs.hpp
@@ -146,6 +146,9 @@ private:
   // Returns 1 if found, 0 if not.
   static int findType(const char* typeName) NOT_VM_STRUCTS_RETURN_(0);
 #endif // ASSERT
+
+public:
+  static void compact_headers_overrides() NOT_VM_STRUCTS_RETURN;
 };
 
 // This utility macro quotes the passed string


### PR DESCRIPTION
Allowing external tools to access e.g. `oopDesc::_metadata._klass` with `+UCOH` is error-prone. We have seen async-profiler poking into this field to resolve classes: https://github.com/async-profiler/async-profiler/blob/117594bb4d1ce61b073c8a9cea438b33f3f09c81/src/vmStructs.cpp#L158-L161

This hides the fields from vmStructs with +UCOH. This is the least intrusive way of achieving this I can come up with.

Additional testing:
 - [x] Eyeballing instrumented async-profiler initialization path
 - [x] Linux x86_64 fastdebug `serviceability/sa`, default
 - [x] Linux x86_64 fastdebug `serviceability/sa`, `+UCOH`
 - [x] Linux x86_64 fastdebug `tier1 tier2`, default
 - [x] Linux x86_64 fastdebug `tier1 tier2`, `+UCOH`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311866](https://bugs.openjdk.org/browse/JDK-8311866): [Lilliput/JDK17] Disallow accessing oop metadata vmStructs with +UCOH (**Bug** - P2)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to [63fe9746](https://git.openjdk.org/lilliput-jdk17u/pull/51/files/63fe974611e2d8349bb40f124d34fc92368398fa)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [63fe9746](https://git.openjdk.org/lilliput-jdk17u/pull/51/files/63fe974611e2d8349bb40f124d34fc92368398fa)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/51/head:pull/51` \
`$ git checkout pull/51`

Update a local copy of the PR: \
`$ git checkout pull/51` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/51/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 51`

View PR using the GUI difftool: \
`$ git pr show -t 51`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/51.diff">https://git.openjdk.org/lilliput-jdk17u/pull/51.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/51#issuecomment-1630617019)