### PR TITLE
8312171: [Lilliput/JDK17] Fix oop array element alignment

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/Universe.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/Universe.java
@@ -114,13 +114,6 @@ public class Universe {
     heap().printOn(tty);
   }
 
-  // Check whether an element of a typeArrayOop with the given type must be
-  // aligned 0 mod 8.  The typeArrayOop itself must be aligned at least this
-  // strongly.
-  public static boolean elementTypeShouldBeAligned(BasicType type) {
-    return type == BasicType.T_DOUBLE || type == BasicType.T_LONG;
-  }
-
   // Check whether an object field (static/non-static) of the given type must be
   // aligned 0 mod 8.
   public static boolean fieldTypeShouldBeAligned(BasicType type) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Array.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Array.java
@@ -57,6 +57,18 @@ public class Array extends Oop {
   private static long lengthOffsetInBytes=0;
   private static long typeSize;
 
+  // Check whether an element of a typeArrayOop with the given type must be
+  // aligned 0 mod 8.  The typeArrayOop itself must be aligned at least this
+  // strongly.
+  public static boolean elementTypeShouldBeAligned(BasicType type) {
+    if (VM.getVM().isLP64()) {
+      if (type == BasicType.T_OBJECT || type == BasicType.T_ARRAY) {
+        return !VM.getVM().isCompressedOopsEnabled();
+      }
+    }
+    return type == BasicType.T_DOUBLE || type == BasicType.T_LONG;
+  }
+
   private static long headerSizeInBytes() {
     if (headerSize != 0) {
       return headerSize;
@@ -75,7 +87,7 @@ public class Array extends Oop {
   }
 
   private static long headerSize(BasicType type) {
-     if (Universe.elementTypeShouldBeAligned(type)) {
+     if (elementTypeShouldBeAligned(type)) {
         return alignObjectSize(headerSizeInBytes())/VM.getVM().getHeapWordSize();
      } else {
        return headerSizeInBytes()/VM.getVM().getHeapWordSize();
@@ -118,7 +130,7 @@ public class Array extends Oop {
   public static long baseOffsetInBytes(BasicType type) {
     if (VM.getVM().isCompactObjectHeadersEnabled()) {
       long typeSizeInBytes = headerSizeInBytes();
-      if (Universe.elementTypeShouldBeAligned(type)) {
+      if (elementTypeShouldBeAligned(type)) {
         VM vm = VM.getVM();
         return vm.alignUp(typeSizeInBytes, vm.getVM().getHeapWordSize());
       } else {


### PR DESCRIPTION
When running with -COOPS, oop array elements need to be 8-byte-aligned. We have this correct in runtime, but not in the SA. Notably, the problem manifests with ZGC.

This is a straight backport of https://github.com/openjdk/lilliput/pull/96.

The problem is already fixed in https://github.com/openjdk/jdk/pull/11044.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312171](https://bugs.openjdk.org/browse/JDK-8312171): [Lilliput/JDK17] Fix oop array element alignment (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/53.diff">https://git.openjdk.org/lilliput-jdk17u/pull/53.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/53#issuecomment-1637917621)