### PR TITLE
8314131: [Lilliput/JDK17] Make loadNKlassCompactHeaders not use a TEMP register

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -7488,7 +7488,7 @@ instruct loadNKlass(iRegNNoSp dst, memory4 mem)
 instruct loadNKlassLilliput(iRegNNoSp dst, memory4 mem, rFlagsReg cr)
 %{
   match(Set dst (LoadNKlass mem));
-  effect(TEMP_DEF dst, KILL cr);
+  effect(KILL cr);
   predicate(!needs_acquiring_load(n) && UseCompactObjectHeaders);
 
   ins_cost(4 * INSN_COST);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -5207,7 +5207,7 @@ instruct loadNKlassLilliput(rRegN dst, indOffset8 mem, rFlagsReg cr)
 %{
   predicate(UseCompactObjectHeaders);
   match(Set dst (LoadNKlass mem));
-  effect(TEMP_DEF dst, KILL cr);
+  effect(KILL cr);
   ins_cost(125); // XXX
   format %{ "movl    $dst, $mem\t# compressed klass ptr" %}
   ins_encode %{


### PR DESCRIPTION
The loadNKlassCompactHeaders template in the .ad files currently declares dst as TEMP_DEF. This has historic reasons: We needed to ensure that dst doesn't overlap with src, because we needed src for calling into the slow-path. In addition to that, there seems to be a related bug in C2's matcher which sometimes seems to create an oopmap entry for a temp reg, which would make GCs crash if they scan uninitialized slot (see [JDK-8051805](https://bugs.openjdk.org/browse/JDK-8051805)). That problem should also go away with this change. In addition to that, relaxing the type of dst might also lead to performance enhancements when register pressure is high, because we don't need two registers for loadNKlass - 1 register would be enough.

Testing:
 - [x] tier1 +UseCompactObjectHeaders (aarch64, x86_64)
 - [x] tier2 +UseCompactObjectHeaders (aarch64, x86_64)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314131](https://bugs.openjdk.org/browse/JDK-8314131): [Lilliput/JDK17] Make loadNKlassCompactHeaders not use a TEMP register (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/55.diff">https://git.openjdk.org/lilliput-jdk17u/pull/55.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/55#issuecomment-1674018185)