### PR TITLE
8314894: [Lilliput/JDK17] Revert changes in zRelocate, prevent ZGC with Lilliput

### DIFF
--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -23,7 +23,6 @@
 
 #include "precompiled.hpp"
 #include "gc/shared/gc_globals.hpp"
-#include "gc/shared/suspendibleThreadSet.hpp"
 #include "gc/z/zAbort.inline.hpp"
 #include "gc/z/zAddress.inline.hpp"
 #include "gc/z/zBarrier.inline.hpp"
@@ -333,10 +332,6 @@ private:
       _target->reset_for_in_place_relocation();
       _forwarding->set_in_place();
     }
-
-    if (SuspendibleThreadSet::should_yield()) {
-      SuspendibleThreadSet::yield();
-    }
   }
 
 public:
@@ -408,7 +403,6 @@ public:
     ZRelocateClosure<ZRelocateSmallAllocator> small(&_small_allocator);
     ZRelocateClosure<ZRelocateMediumAllocator> medium(&_medium_allocator);
 
-    SuspendibleThreadSetJoiner sts_joiner;
     for (ZForwarding* forwarding; _iter.next(&forwarding);) {
       if (is_small(forwarding)) {
         small.do_forwarding(forwarding);

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3170,6 +3170,11 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
 #endif // CAN_SHOW_REGISTERS_ON_ASSERT
 
 #ifdef _LP64
+  if (UseCompactObjectHeaders && UseZGC) {
+    warning("ZGC does not work with compact object headers, disabling UseCompactObjectHeaders");
+    FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
+  }
+
   if (UseCompactObjectHeaders && FLAG_IS_CMDLINE(UseCompressedClassPointers) && !UseCompressedClassPointers) {
     // If user specifies -UseCompressedClassPointers, disable compact headers with a warning.
     warning("Compact object headers require compressed class pointers. Disabling compact object headers.");


### PR DESCRIPTION
The additions of SuspendibleThreadSet in [zRelocate.cpp](https://builds.shipilev.net/patch-openjdk-lilliput/src/hotspot/share/gc/z/zRelocate.cpp.udiff.html) can cause deadlocks. This problem can not easily be solved without major work in Lilliput. Let's revert those changes and prevent usage of ZGC together with Lilliput.

Testing:
 - [x] hotspot_gc +UCOH
 - [x] hotspot_gc -UCOH (default)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314894](https://bugs.openjdk.org/browse/JDK-8314894): [Lilliput/JDK17] Revert changes in zRelocate, prevent ZGC with Lilliput (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/56/head:pull/56` \
`$ git checkout pull/56`

Update a local copy of the PR: \
`$ git checkout pull/56` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/56/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 56`

View PR using the GUI difftool: \
`$ git pr show -t 56`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/56.diff">https://git.openjdk.org/lilliput-jdk17u/pull/56.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/56#issuecomment-1690080916)