### PR TITLE
8318172: [Lilliput/JDK17] Disable Lilliput in TestZGCWithCDS

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestZGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestZGCWithCDS.java
@@ -47,6 +47,7 @@ public class TestZGCWithCDS {
                                   .dump(helloJar,
                                         new String[] {"Hello"},
                                         "-XX:+UseZGC",
+                                        "-XX:-UseCompactObjectHeaders",
                                         "-Xlog:cds");
          out.shouldContain("Dumping shared data to file:");
          out.shouldHaveExitValue(0);
@@ -55,6 +56,7 @@ public class TestZGCWithCDS {
          out = TestCommon
                    .exec(helloJar,
                          "-XX:+UseZGC",
+                         "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds",
                          "Hello");
          out.shouldContain(HELLO);
@@ -66,6 +68,7 @@ public class TestZGCWithCDS {
                          "-XX:-UseZGC",
                          "-XX:+UseCompressedOops",           // in case turned off by vmoptions
                          "-XX:+UseCompressedClassPointers",  // by jtreg
+                         "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds",
                          "Hello");
          out.shouldContain(UNABLE_TO_USE_ARCHIVE);
@@ -78,6 +81,7 @@ public class TestZGCWithCDS {
                          "-XX:+UseSerialGC",
                          "-XX:-UseCompressedOops",
                          "-XX:-UseCompressedClassPointers",
+                         "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds",
                          "Hello");
          out.shouldContain(UNABLE_TO_USE_ARCHIVE);
@@ -90,6 +94,7 @@ public class TestZGCWithCDS {
                          "-XX:+UseSerialGC",
                          "-XX:-UseCompressedOops",
                          "-XX:+UseCompressedClassPointers",
+                         "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds",
                          "Hello");
          out.shouldContain(HELLO);
@@ -101,6 +106,7 @@ public class TestZGCWithCDS {
                          "-XX:+UseSerialGC",
                          "-XX:+UseCompressedOops",
                          "-XX:-UseCompressedClassPointers",
+                         "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds",
                          "Hello");
          out.shouldContain(UNABLE_TO_USE_ARCHIVE);
@@ -113,6 +119,7 @@ public class TestZGCWithCDS {
                          "-XX:+UseSerialGC",
                          "-XX:+UseCompressedOops",
                          "-XX:+UseCompressedClassPointers",
+                         "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds",
                          "Hello");
          out.shouldContain(UNABLE_TO_USE_ARCHIVE);
@@ -126,6 +133,7 @@ public class TestZGCWithCDS {
                          "-XX:+UseSerialGC",
                          "-XX:-UseCompressedOops",
                          "-XX:+UseCompressedClassPointers",
+                         "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds");
          out.shouldContain("Dumping shared data to file:");
          out.shouldHaveExitValue(0);
@@ -134,6 +142,7 @@ public class TestZGCWithCDS {
          out = TestCommon
                    .exec(helloJar,
                          "-XX:+UseZGC",
+                         "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds",
                          "Hello");
          out.shouldContain(HELLO);

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestZGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestZGCWithCDS.java
@@ -47,6 +47,7 @@ public class TestZGCWithCDS {
                                   .dump(helloJar,
                                         new String[] {"Hello"},
                                         "-XX:+UseZGC",
+                                        "-XX:+UnlockExperimentalVMOptions",
                                         "-XX:-UseCompactObjectHeaders",
                                         "-Xlog:cds");
          out.shouldContain("Dumping shared data to file:");
@@ -56,6 +57,7 @@ public class TestZGCWithCDS {
          out = TestCommon
                    .exec(helloJar,
                          "-XX:+UseZGC",
+                         "-XX:+UnlockExperimentalVMOptions",
                          "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds",
                          "Hello");
@@ -68,6 +70,7 @@ public class TestZGCWithCDS {
                          "-XX:-UseZGC",
                          "-XX:+UseCompressedOops",           // in case turned off by vmoptions
                          "-XX:+UseCompressedClassPointers",  // by jtreg
+                         "-XX:+UnlockExperimentalVMOptions",
                          "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds",
                          "Hello");
@@ -81,6 +84,7 @@ public class TestZGCWithCDS {
                          "-XX:+UseSerialGC",
                          "-XX:-UseCompressedOops",
                          "-XX:-UseCompressedClassPointers",
+                         "-XX:+UnlockExperimentalVMOptions",
                          "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds",
                          "Hello");
@@ -94,6 +98,7 @@ public class TestZGCWithCDS {
                          "-XX:+UseSerialGC",
                          "-XX:-UseCompressedOops",
                          "-XX:+UseCompressedClassPointers",
+                         "-XX:+UnlockExperimentalVMOptions",
                          "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds",
                          "Hello");
@@ -106,6 +111,7 @@ public class TestZGCWithCDS {
                          "-XX:+UseSerialGC",
                          "-XX:+UseCompressedOops",
                          "-XX:-UseCompressedClassPointers",
+                         "-XX:+UnlockExperimentalVMOptions",
                          "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds",
                          "Hello");
@@ -119,6 +125,7 @@ public class TestZGCWithCDS {
                          "-XX:+UseSerialGC",
                          "-XX:+UseCompressedOops",
                          "-XX:+UseCompressedClassPointers",
+                         "-XX:+UnlockExperimentalVMOptions",
                          "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds",
                          "Hello");
@@ -133,6 +140,7 @@ public class TestZGCWithCDS {
                          "-XX:+UseSerialGC",
                          "-XX:-UseCompressedOops",
                          "-XX:+UseCompressedClassPointers",
+                         "-XX:+UnlockExperimentalVMOptions",
                          "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds");
          out.shouldContain("Dumping shared data to file:");
@@ -142,6 +150,7 @@ public class TestZGCWithCDS {
          out = TestCommon
                    .exec(helloJar,
                          "-XX:+UseZGC",
+                         "-XX:+UnlockExperimentalVMOptions",
                          "-XX:-UseCompactObjectHeaders",
                          "-Xlog:cds",
                          "Hello");


### PR DESCRIPTION
Lilliput is not supported by ZGC, and when running with both -XX:+UseZGC and -XX:+UseCompactObjectHeaders, the latter is disabled with a warning. Unfortunately, this breaks the test TestZGCWithCDS, because it would generate a CDS archive with SerialGC - with -XX:+UseCompactObjectHeaders - and then attempts to load it with ZGC -which disables UseCompactObjectHeaders, which makes CDS archives incompatible.

Testing:
 - [x] runtime/cds/appcds/TestZGCWithCDS.java +UCOH
 - [x] runtime/cds/appcds/TestZGCWithCDS.java -UCOH
 - [x] runtime/cds/appcds/TestZGCWithCDS.java default

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318172](https://bugs.openjdk.org/browse/JDK-8318172): [Lilliput/JDK17] Disable Lilliput in TestZGCWithCDS (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/60.diff">https://git.openjdk.org/lilliput-jdk17u/pull/60.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/60#issuecomment-1764880408)