### PR TITLE
8319724: [Lilliput] ParallelGC: Forwarded objects found during heap inspection

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -233,11 +233,36 @@ void MutableSpace::oop_iterate(OopIterateClosure* cl) {
   }
 }
 
-void MutableSpace::object_iterate(ObjectClosure* cl) {
+template<bool COMPACT_HEADERS>
+void MutableSpace::object_iterate_impl(ObjectClosure* cl) {
   HeapWord* p = bottom();
   while (p < top()) {
-    cl->do_object(cast_to_oop(p));
-    p += cast_to_oop(p)->size();
+    oop obj = cast_to_oop(p);
+    // When promotion-failure occurs during Young GC, eden/from space is not cleared,
+    // so we can encounter objects with "forwarded" markword.
+    // They are essentially dead, so skipping them
+    if (!obj->is_forwarded()) {
+      cl->do_object(obj);
+      p += obj->size();
+    } else {
+      assert(obj->forwardee() != obj, "must not be self-forwarded");
+      if (COMPACT_HEADERS) {
+        // It is safe to use the forwardee here. Parallel GC only uses
+        // header-based forwarding during promotion. Full GC doesn't
+        // use the object header for forwarding at all.
+        p += obj->forwardee()->size();
+      } else {
+        p += obj->size();
+      }
+    }
+  }
+}
+
+void MutableSpace::object_iterate(ObjectClosure* cl) {
+  if (UseCompactObjectHeaders) {
+    object_iterate_impl<true>(cl);
+  } else {
+    object_iterate_impl<false>(cl);
   }
 }
 

--- a/src/hotspot/share/gc/parallel/mutableSpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.hpp
@@ -67,6 +67,9 @@ class MutableSpace: public CHeapObj<mtGC> {
   void set_last_setup_region(MemRegion mr) { _last_setup_region = mr;   }
   MemRegion last_setup_region() const      { return _last_setup_region; }
 
+  template<bool COMPACT_HEADERS>
+  void object_iterate_impl(ObjectClosure* cl);
+
  public:
   virtual ~MutableSpace();
   MutableSpace(size_t page_size);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [0568386e](https://github.com/openjdk/lilliput/commit/0568386e062474b1fc31e2e7106db0079ded7d76) from the [openjdk/lilliput](https://git.openjdk.org/lilliput) repository.

The commit being backported was authored by Roman Kennke on 9 Nov 2023 and was reviewed by Aleksey Shipilev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319724](https://bugs.openjdk.org/browse/JDK-8319724): [Lilliput] ParallelGC: Forwarded objects found during heap inspection (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/62/head:pull/62` \
`$ git checkout pull/62`

Update a local copy of the PR: \
`$ git checkout pull/62` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/62/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 62`

View PR using the GUI difftool: \
`$ git pr show -t 62`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/62.diff">https://git.openjdk.org/lilliput-jdk17u/pull/62.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/62#issuecomment-1803585692)