### PR TITLE
8321135: [Lilliput/JDK17] Fix repo permissions

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,7 +1,7 @@
 [general]
-project=jdk-updates
+project=lilliput
 jbs=JDK
-version=17.0.10
+version=17
 
 [checks]
 error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists
@@ -22,7 +22,7 @@ ignore-tabs=.*\.gmk|Makefile
 message=Merge
 
 [checks "reviewers"]
-reviewers=1
+committers=1
 ignore=duke
 
 [checks "committer"]


### PR DESCRIPTION
The Lilliput/JDK17u repo has the wrong permissons: it inherits permissions from jdk-updates, but should use permission from she Shenandoah project instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321135](https://bugs.openjdk.org/browse/JDK-8321135): [Lilliput/JDK17] Fix repo permissions (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/67.diff">https://git.openjdk.org/lilliput-jdk17u/pull/67.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/67#issuecomment-1834287302)