### PR TITLE
8316735: Print LockStack in hs_err files

### DIFF
--- a/src/hotspot/share/runtime/lockStack.cpp
+++ b/src/hotspot/share/runtime/lockStack.cpp
@@ -77,3 +77,15 @@ void LockStack::verify(const char* msg) const {
   }
 }
 #endif
+
+void LockStack::print_on(outputStream* st) {
+  for (int i = to_index(_top); (--i) >= 0;) {
+    st->print("LockStack[%d]: ", i);
+    oop o = _base[i];
+    if (oopDesc::is_oop(o)) {
+      o->print_on(st);
+    } else {
+      st->print_cr("not an oop: " PTR_FORMAT, p2i(o));
+    }
+  }
+}

--- a/src/hotspot/share/runtime/lockStack.hpp
+++ b/src/hotspot/share/runtime/lockStack.hpp
@@ -30,8 +30,9 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/sizes.hpp"
 
-class Thread;
+class JavaThread;
 class OopClosure;
+class outputStream;
 
 class LockStack {
   friend class VMStructs;
@@ -91,6 +92,8 @@ public:
   // GC support
   inline void oops_do(OopClosure* cl);
 
+  // Printing
+  void print_on(outputStream* st);
 };
 
 #endif // SHARE_RUNTIME_LOCKSTACK_HPP

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -946,6 +946,14 @@ void VMError::report(outputStream* st, bool _verbose) {
        st->cr();
      }
 
+  STEP("printing lock stack")
+
+    if (_verbose && _thread != nullptr && _thread->is_Java_thread() && LockingMode == LM_LIGHTWEIGHT) {
+      st->print_cr("Lock stack of current Java thread (top to bottom):");
+      reinterpret_cast<JavaThread*>(_thread)->lock_stack().print_on(st);
+      st->cr();
+    }
+
   STEP("printing code blobs if possible")
 
      if (_verbose) {

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -950,7 +950,7 @@ void VMError::report(outputStream* st, bool _verbose) {
 
     if (_verbose && _thread != nullptr && _thread->is_Java_thread() && LockingMode == LM_LIGHTWEIGHT) {
       st->print_cr("Lock stack of current Java thread (top to bottom):");
-      reinterpret_cast<JavaThread*>(_thread)->lock_stack().print_on(st);
+      _thread->as_Java_thread()->lock_stack().print_on(st);
       st->cr();
     }
 


### PR DESCRIPTION
I'd like to backport https://github.com/openjdk/jdk/commit/20ff603108a52468dd41020cbf6c0bf669e23861, it is a nice improvement, and eases subsequent backports. The backport was not clean, there have been some context diffs and the macro structure in vmError.cpp is different.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8316735](https://bugs.openjdk.org/browse/JDK-8316735): Print LockStack in hs_err files (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/70.diff">https://git.openjdk.org/lilliput-jdk17u/pull/70.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/70#issuecomment-2039386908)