### PR TITLE
8319897: Move StackWatermark handling out of LockStack::contains

### DIFF
--- a/src/hotspot/share/runtime/lockStack.inline.hpp
+++ b/src/hotspot/share/runtime/lockStack.inline.hpp
@@ -104,16 +104,10 @@ inline void LockStack::remove(oop o) {
 
 inline bool LockStack::contains(oop o) const {
   verify("pre-contains");
-  if (!SafepointSynchronize::is_at_safepoint() && !is_owning_thread()) {
-    // When a foreign thread inspects this thread's lock-stack, it may see
-    // bad references here when a concurrent collector has not gotten
-    // to processing the lock-stack, yet. Call StackWaterMark::start_processing()
-    // to ensure that all references are valid.
-    StackWatermark* watermark = StackWatermarkSet::get(get_thread(), StackWatermarkKind::gc);
-    if (watermark != NULL) {
-      watermark->start_processing();
-    }
-  }
+
+  // Can't poke around in thread oops without having started stack watermark processing.
+  assert(StackWatermarkSet::processing_started(get_thread()), "Processing must have started!");
+
   int end = to_index(_top);
   for (int i = end - 1; i >= 0; i--) {
     if (_base[i] == o) {


### PR DESCRIPTION
Backport of https://github.com/openjdk/jdk/commit/bbf52e0e4cb76b4c6425e7d1266dcdbb4df556ea

It's an enhancement to LW locking, backported to keep lockStack code in sync, to ease subsequent backports.

Slightly unclean because of NULL vs nullptr diff.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8319897](https://bugs.openjdk.org/browse/JDK-8319897): Move StackWatermark handling out of LockStack::contains (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk17u.git pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.org/lilliput-jdk17u.git pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk17u/pull/78.diff">https://git.openjdk.org/lilliput-jdk17u/pull/78.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk17u/pull/78#issuecomment-2044381604)